### PR TITLE
refactor: commands parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,16 +82,19 @@ expansion of the format string.
 
 ### `@popup-on-open`
 
-**Default**: `set exit-empty off ; set status off`
+**Default**: `set exit-empty off \; set status off`
 
 **Example**:
 
 ```tmux
-# you can use braces for more concise syntax
-set -g @popup-on-open {
+set -g @popup-on-open '
   set exit-empty off
   set status off
-}
+'
+# escaping "\;" is required when binding key to multiple commands
+set -g @popup-on-init '
+  bind M-r display "some text" \\\; display "another text"
+'
 ```
 
 **Description**: Run extra commands in the popup every time after it's opened.

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -6,8 +6,14 @@ showopt() {
 	echo "${v:-"$2"}"
 }
 
-makecmd() {
-	tr '\n' ';' | sed 's/;/ \\; /g'
+escape() {
+	if [ $# -gt 0 ]; then
+		printf '%q ' "$@"
+	fi
+}
+
+joincmd() {
+	sed 's/$/ \\;/' | tr '\n' ' '
 }
 
 bindkey() {


### PR DESCRIPTION
Use bash(1) to parse user-defined Tmux commands. Semicolons in hooks (`@popup-on-open` and `@popup-on-close`) must now be explicitly escaped or quoted.