### PR TITLE
refactor: hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ interpretation.
 **Example**:
 
 ```tmux
-set -g @popup-on-open '
+set -g @popup-on-init '
   set exit-empty off
   set status off
 '
@@ -101,11 +101,12 @@ set -g @popup-on-init '
 '
 ```
 
-### `@popup-on-open`
+### `@popup-on-init`
 
 **Default**: `set exit-empty off \; set status off`
 
-**Description**: Run extra commands in the popup every time after it's opened.
+**Description**: Additional commands that initialize a popup, executed within the popup each time
+after it is opened.
 
 ## ⌨️ Keybindings
 

--- a/README.md
+++ b/README.md
@@ -80,9 +80,13 @@ sessions, and within each session, popups are shared among the same project (ide
 directory name). A variable named `@popup_name` is assigned the name of the popup during the
 expansion of the format string.
 
-### `@popup-on-open`
+## 🪝 Hooks
 
-**Default**: `set exit-empty off \; set status off`
+A hook consists of Tmux commands delimited by semicolons (`;`). Each hook is interpreted by bash(1)
+as a sequence of shell arguments, which are then passed to tmux(1). Hence, semicolons should be
+escaped (`\;`) or quoted (`";"`) to prevent them from being recognized as bash command delimiters.
+Each command can alternatively be delimited by a line break, which is substituted with `\;` before
+interpretation.
 
 **Example**:
 
@@ -96,6 +100,10 @@ set -g @popup-on-init '
   bind M-r display "some text" \\\; display "another text"
 '
 ```
+
+### `@popup-on-open`
+
+**Default**: `set exit-empty off \; set status off`
 
 **Description**: Run extra commands in the popup every time after it's opened.
 

--- a/README.md
+++ b/README.md
@@ -107,12 +107,6 @@ set -g @popup-on-init '
 
 **Description**: Run extra commands in the popup every time after it's opened.
 
-### `@popup-on-close`
-
-**Default**: empty
-
-**Description**: Similar to `@popup-on-open`, but executed before the popup is closed.
-
 ## ⌨️ Keybindings
 
 ### `@popup-toggle`

--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ escaped (`\;`) or quoted (`";"`) to prevent them from being recognized as bash c
 Each command can alternatively be delimited by a line break, which is substituted with `\;` before
 interpretation.
 
+A hook will be executed either in the caller (i.e., the session that calls `@popup-toggle`) or in
+the popup (i.e., the session that opens as a popup).
+
 **Example**:
 
 ```tmux
@@ -105,8 +108,22 @@ set -g @popup-on-init '
 
 **Default**: `set exit-empty off \; set status off`
 
-**Description**: Additional commands that initialize a popup, executed within the popup each time
-after it is opened.
+**Description**: Additional commands that are executed within the popup each time after it is
+opened.
+
+### `@popup-before-open`
+
+**Default**: empty
+
+**Description**: Additional commands that are executed within the caller each time before a popup is
+opened.
+
+### `@popup-after-close`
+
+**Default**: empty
+
+**Description**: Additional commands that are executed within the caller each time after a popup is
+closed.
 
 ## ⌨️ Keybindings
 

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -35,6 +35,12 @@ showopt() {
 	echo "${v:-"$2"}"
 }
 
+# Returns the specified option as a hook, which consists of a sequence of Tmux
+# commands.
+showhook() {
+	showopt "$@" | joincmd
+}
+
 # Expand the provided Tmux FORMAT string. The last argument is the format
 # string, while the preceding ones represent variables available during the
 # expansion.

--- a/scripts/toggle.sh
+++ b/scripts/toggle.sh
@@ -8,8 +8,7 @@ source "$CURRENT_DIR/helpers.sh"
 DEFAULT_NAME='default'
 DEFAULT_SOCKET_NAME='popup'
 DEFAULT_ID_FORMAT='#{b:socket_path}/#{session_name}/#{b:pane_current_path}/#{@popup_name}'
-DEFAULT_ON_OPEN="set exit-empty off \; set status off"
-DEFAULT_ON_CLOSE=''
+DEFAULT_ON_INIT="set exit-empty off \; set status off"
 
 declare name popup_args cmd OPT OPTARG OPTIND=1
 
@@ -59,12 +58,10 @@ else
 	id_format="$(showopt @popup-id-format "$DEFAULT_ID_FORMAT")"
 	popup_id="$(format @popup_name "$name" "$id_format")"
 
-	tmux popup "${popup_args[@]}" "$(
-		cat <<-EOF | joincmd
-			tmux -L '$socket_name'
-				new -As '$popup_id' $(escape "${cmd[@]}")
-				set @__popup_opened '$name'
-				$(showopt @popup-on-open "$DEFAULT_ON_OPEN")
-		EOF
-	) >/dev/null"
+	tmux popup "${popup_args[@]}" "
+		tmux -L '$socket_name' \
+			new -As '$popup_id' $(escape "${cmd[@]}") \; \
+			set @__popup_opened '$name' \; \
+			$(showhook @popup-on-init "$DEFAULT_ON_INIT") \; \
+			>/dev/null"
 fi

--- a/scripts/toggle.sh
+++ b/scripts/toggle.sh
@@ -52,14 +52,7 @@ opened="$(showopt @__popup_opened)"
 if [[ -n "$opened" && ("$opened" = "$name" || -z "$*") ]]; then
 	# Clear the variables to prevent a manually attached session from being
 	# detached by the keybinding.
-	eval "$(
-		cat <<-EOF | joincmd
-			tmux
-				$(showopt @popup-on-close "$DEFAULT_ON_CLOSE")
-				set -u @__popup_opened
-				detach
-		EOF
-	)"
+	tmux set -u @__popup_opened \; detach
 else
 	name="${name:-"$DEFAULT_NAME"}"
 	socket_name="$(showopt @popup-socket-name "$DEFAULT_SOCKET_NAME")"

--- a/scripts/toggle.sh
+++ b/scripts/toggle.sh
@@ -58,10 +58,12 @@ else
 	id_format="$(showopt @popup-id-format "$DEFAULT_ID_FORMAT")"
 	popup_id="$(format @popup_name "$name" "$id_format")"
 
+	eval "tmux -C \; $(showhook @popup-before-open) >/dev/null"
 	tmux popup "${popup_args[@]}" "
 		tmux -L '$socket_name' \
 			new -As '$popup_id' $(escape "${cmd[@]}") \; \
 			set @__popup_opened '$name' \; \
 			$(showhook @popup-on-init "$DEFAULT_ON_INIT") \; \
 			>/dev/null"
+	eval "tmux -C \; $(showhook @popup-after-close) >/dev/null"
 fi


### PR DESCRIPTION
1. Add two new hooks: `@popup-before-open` and `@popup-after-close`, which are executed within the caller.
2. Rename `@popup-on-open` to the more intuitive name `@popup-on-init`.
3. Remove the `@popup-on-close` hook, as it cannot handle popup exits. Instead, consider setting the `client-detached` and `pane-exited` hooks in `@popup-on-init`.