### PR TITLE
feat(keybinding): add `@popup-focus` to manually fire focus events

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,14 +146,42 @@ USAGE:
 
 OPTION:
 
-  --name <name>  Popup name [Default: "default"]
-  -[BCE]         Flags passed to display-popup
+  --name <name>     Popup name [Default: "default"]
+  -[BCE]            Flags passed to display-popup
   -[bcdehsStTwxy] <value>
-                 Options passed to display-popup
+                    Options passed to display-popup
 
 EXAMPLES:
 
   toggle.sh -Ed'#{pane_current_path}' --name=bash bash
+```
+
+### `@popup-focus`
+
+**Example**:
+
+A workaround of tmux/tmux#3991.
+
+```tmux
+set -g @popup-before-open 'run "#{@popup-focus} --leave nvim"'
+set -g @popup-after-close 'run "#{@popup-focus} --enter nvim"'
+```
+
+**Description**: Manually fire focus enter and leave events.
+
+```text
+USAGE:
+
+  focus.sh [OPTION]... [PROGRAM]...
+
+OPTION:
+
+  --enter           Send focus enter event [Default mode]
+  --leave           Send focus leave event
+
+EXAMPLES:
+
+  focus.sh --enter nvim emacs
 ```
 
 ## ⚖️ License

--- a/scripts/focus.sh
+++ b/scripts/focus.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=./helpers.sh
+source "$CURRENT_DIR/helpers.sh"
+
+declare mode=I progs OPT OPTARG OPTIND=1
+
+while getopts :-: OPT; do
+	if [ "$OPT" = "-" ]; then OPT="$OPTARG"; fi
+	case "$OPT" in
+	enter) mode=I ;;
+	leave) mode=O ;;
+	help)
+		cat <<-EOF
+			USAGE:
+
+			  focus.sh [OPTION]... [PROGRAM]...
+
+			OPTION:
+
+			  --enter           Send focus enter event [Default mode]
+			  --leave           Send focus leave event
+
+			EXAMPLES:
+
+			  focus.sh --enter nvim emacs
+		EOF
+		exit
+		;;
+	*) badopt ;;
+	esac
+done
+progs=("${@:$OPTIND}")
+
+check() {
+	if [ ${#progs} = 0 ]; then
+		return
+	fi
+
+	for prog in "${progs[@]}"; do
+		if [ "$(format '#{pane_current_command}')" = "$prog" ]; then
+			return
+		fi
+	done
+
+	return 1
+}
+if check; then
+	tmux send Escape "[$mode"
+fi

--- a/toggle-popup.tmux
+++ b/toggle-popup.tmux
@@ -3,4 +3,6 @@
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Set keybindings
-tmux set -g @popup-toggle "$CURRENT_DIR/scripts/toggle.sh"
+for key in toggle focus; do
+	tmux set -g "@popup-$key" "$CURRENT_DIR/scripts/$key.sh"
+done


### PR DESCRIPTION
Add `@popup-focus`, primarily used as a workaround of tmux/tmux#3991.