### PR TITLE
release: v0.2.0

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+## 0.2.0 (2024-06-05)
+
+### Breaking changes
+
+- Tmux commands are parsed by bash(1), thus semicolons in hooks (`@popup-on-open` and
+  `@popup-on-close`) must now be explicitly escaped or quoted (#1).
+- `@popup-on-open` is renamed to `@popup-on-init` (#2).
+- `@popup-on-close` is removed, as it cannot handle popup exits (#2). Instead, consider setting the
+  `client-detached` and `pane-exited` hooks in `@popup-on-init`.
+
+### Features
+
+- Add two new hooks: `@popup-before-open` and `@popup-after-close` (#2).
+- Add `@popup-focus`, primarily used as a workaround of tmux/tmux#3991 (#3).
+
+## v0.1.0 (2024-05-31)
+
+Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Add two new hooks: `@popup-before-open` and `@popup-after-close`
   ([#2](https://github.com/loichyan/tmux-toggle-popup/pull/2)).
 - Add `@popup-focus`, primarily used as a workaround of
-  [tmux/tmux#3](https://github.com/tmux/tmux/issue/3991)
+  [tmux/tmux#3](https://github.com/tmux/tmux/issues/3991)
   ([#3](https://github.com/loichyan/tmux-toggle-popup/pull/3)).
 
 ## v0.1.0 (2024-05-31)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,21 @@
 ### Breaking changes
 
 - Tmux commands are parsed by bash(1), thus semicolons in hooks (`@popup-on-open` and
-  `@popup-on-close`) must now be explicitly escaped or quoted (#1).
-- `@popup-on-open` is renamed to `@popup-on-init` (#2).
-- `@popup-on-close` is removed, as it cannot handle popup exits (#2). Instead, consider setting the
+  `@popup-on-close`) must now be explicitly escaped or quoted
+  ([#1](https://github.com/loichyan/tmux-toggle-popup/pulls/1)).
+- `@popup-on-open` is renamed to `@popup-on-init`
+  ([#2](https://github.com/loichyan/tmux-toggle-popup/pulls/2)).
+- `@popup-on-close` is removed, as it cannot handle popup exits
+  ([#2](https://github.com/loichyan/tmux-toggle-popup/pulls/2)). Instead, consider setting the
   `client-detached` and `pane-exited` hooks in `@popup-on-init`.
 
 ### Features
 
-- Add two new hooks: `@popup-before-open` and `@popup-after-close` (#2).
-- Add `@popup-focus`, primarily used as a workaround of tmux/tmux#3991 (#3).
+- Add two new hooks: `@popup-before-open` and `@popup-after-close`
+  ([#2](https://github.com/loichyan/tmux-toggle-popup/pulls/2)).
+- Add `@popup-focus`, primarily used as a workaround of
+  [tmux/tmux#3](https://github.com/tmux/tmux/issues/3991)
+  ([#3](https://github.com/loichyan/tmux-toggle-popup/pulls/3)).
 
 ## v0.1.0 (2024-05-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,20 +6,20 @@
 
 - Tmux commands are parsed by bash(1), thus semicolons in hooks (`@popup-on-open` and
   `@popup-on-close`) must now be explicitly escaped or quoted
-  ([#1](https://github.com/loichyan/tmux-toggle-popup/pulls/1)).
+  ([#1](https://github.com/loichyan/tmux-toggle-popup/pull/1)).
 - `@popup-on-open` is renamed to `@popup-on-init`
-  ([#2](https://github.com/loichyan/tmux-toggle-popup/pulls/2)).
+  ([#2](https://github.com/loichyan/tmux-toggle-popup/pull/2)).
 - `@popup-on-close` is removed, as it cannot handle popup exits
-  ([#2](https://github.com/loichyan/tmux-toggle-popup/pulls/2)). Instead, consider setting the
+  ([#2](https://github.com/loichyan/tmux-toggle-popup/pull/2)). Instead, consider setting the
   `client-detached` and `pane-exited` hooks in `@popup-on-init`.
 
 ### Features
 
 - Add two new hooks: `@popup-before-open` and `@popup-after-close`
-  ([#2](https://github.com/loichyan/tmux-toggle-popup/pulls/2)).
+  ([#2](https://github.com/loichyan/tmux-toggle-popup/pull/2)).
 - Add `@popup-focus`, primarily used as a workaround of
-  [tmux/tmux#3](https://github.com/tmux/tmux/issues/3991)
-  ([#3](https://github.com/loichyan/tmux-toggle-popup/pulls/3)).
+  [tmux/tmux#3](https://github.com/tmux/tmux/issue/3991)
+  ([#3](https://github.com/loichyan/tmux-toggle-popup/pull/3)).
 
 ## v0.1.0 (2024-05-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,22 +4,14 @@
 
 ### Breaking changes
 
-- Tmux commands are parsed by bash(1), thus semicolons in hooks (`@popup-on-open` and
-  `@popup-on-close`) must now be explicitly escaped or quoted
-  ([#1](https://github.com/loichyan/tmux-toggle-popup/pull/1)).
-- `@popup-on-open` is renamed to `@popup-on-init`
-  ([#2](https://github.com/loichyan/tmux-toggle-popup/pull/2)).
-- `@popup-on-close` is removed, as it cannot handle popup exits
-  ([#2](https://github.com/loichyan/tmux-toggle-popup/pull/2)). Instead, consider setting the
-  `client-detached` and `pane-exited` hooks in `@popup-on-init`.
+- Tmux commands are parsed by bash(1), thus semicolons in hooks (`@popup-on-open` and `@popup-on-close`) must now be explicitly escaped or quoted ([#1](https://github.com/loichyan/tmux-toggle-popup/pull/1)).
+- `@popup-on-open` is renamed to `@popup-on-init` ([#2](https://github.com/loichyan/tmux-toggle-popup/pull/2)).
+- `@popup-on-close` is removed, as it cannot handle popup exits. Instead, consider setting the `client-detached` and `pane-exited` hooks in `@popup-on-init` ([#2](https://github.com/loichyan/tmux-toggle-popup/pull/2)).
 
 ### Features
 
-- Add two new hooks: `@popup-before-open` and `@popup-after-close`
-  ([#2](https://github.com/loichyan/tmux-toggle-popup/pull/2)).
-- Add `@popup-focus`, primarily used as a workaround of
-  [tmux/tmux#3](https://github.com/tmux/tmux/issues/3991)
-  ([#3](https://github.com/loichyan/tmux-toggle-popup/pull/3)).
+- Add two new hooks: `@popup-before-open` and `@popup-after-close` ([#2](https://github.com/loichyan/tmux-toggle-popup/pull/2)).
+- Add `@popup-focus`, primarily used as a workaround of [tmux/tmux#3](https://github.com/tmux/tmux/issues/3991) ([#3](https://github.com/loichyan/tmux-toggle-popup/pull/3)).
 
 ## v0.1.0 (2024-05-31)
 

--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ popup sessions are opened.
 
 **Description**: A format string used to generate IDs for each popup, allowing you to customize how
 popups are shared across sessions, windows, and panes. By default, popups are independent across
-sessions, and within each session, popups are shared among the same project (identified by the
-directory name). A variable named `@popup_name` is assigned the name of the popup during the
-expansion of the format string.
+sessions, and in each session, popups are shared among the same project (identified by the directory
+name). A variable named `@popup_name` is assigned the name of the popup during the expansion of the
+format string.
 
 ## 🪝 Hooks
 
@@ -108,22 +108,19 @@ set -g @popup-on-init '
 
 **Default**: `set exit-empty off \; set status off`
 
-**Description**: Additional commands that are executed within the popup each time after it is
-opened.
+**Description**: Tmux commands executed in the popup each time after it is opened.
 
 ### `@popup-before-open`
 
 **Default**: empty
 
-**Description**: Additional commands that are executed within the caller each time before a popup is
-opened.
+**Description**: Tmux commands executed in the caller each time before a popup is opened.
 
 ### `@popup-after-close`
 
 **Default**: empty
 
-**Description**: Additional commands that are executed within the caller each time after a popup is
-closed.
+**Description**: Tmux commands executed in the caller each time after a popup is closed.
 
 ## ⌨️ Keybindings
 
@@ -135,9 +132,9 @@ closed.
 bind -n M-t run "#{@popup-toggle} -Ed'#{pane_current_path}' -w75% -h75%"
 ```
 
-**Description**: A shell script to toggle a popup: when invoked within a popup of the same name, it
+**Description**: A shell script to toggle a popup: when invoked in a popup of the same name, it
 closes the popup; otherwise, it opens a popup of the specified name. If no argument is provided and
-called within a popup, it will close the popup.
+called in a popup, it will close the popup.
 
 ```text
 USAGE:


### PR DESCRIPTION
### Breaking changes

- Tmux commands are parsed by bash(1), thus semicolons in hooks (`@popup-on-open` and `@popup-on-close`) must now be explicitly escaped or quoted ([#1](https://github.com/loichyan/tmux-toggle-popup/pull/1)).
- `@popup-on-open` is renamed to `@popup-on-init` ([#2](https://github.com/loichyan/tmux-toggle-popup/pull/2)).
- `@popup-on-close` is removed, as it cannot handle popup exits. Instead, consider setting the `client-detached` and `pane-exited` hooks in `@popup-on-init` ([#2](https://github.com/loichyan/tmux-toggle-popup/pull/2)).

### Features

- Add two new hooks: `@popup-before-open` and `@popup-after-close` ([#2](https://github.com/loichyan/tmux-toggle-popup/pull/2)).
- Add `@popup-focus`, primarily used as a workaround of [tmux/tmux#3](https://github.com/tmux/tmux/issues/3991) ([#3](https://github.com/loichyan/tmux-toggle-popup/pull/3)).

