### PR TITLE
fix: forward environment overrides to popup sessions

### DIFF
--- a/scripts/toggle.sh
+++ b/scripts/toggle.sh
@@ -7,13 +7,15 @@ source "$CURRENT_DIR/helpers.sh"
 # shellcheck source=./variables.sh
 source "$CURRENT_DIR/variables.sh"
 
-declare name popup_args cmd OPT OPTARG OPTIND=1
+declare name popup_args session_args cmd OPT OPTARG OPTIND=1
 
 while getopts :-:BCEb:c:d:e:h:s:S:t:T:w:x:y: OPT; do
 	if [[ $OPT == '-' ]]; then OPT="${OPTARG%%=*}"; fi
 	case "$OPT" in
 	[BCE]) popup_args+=("-$OPT") ;;
-	[bcdehsStTwxy]) popup_args+=("-$OPT" "$OPTARG") ;;
+	[bcdhsStTwxy]) popup_args+=("-$OPT" "$OPTARG") ;;
+	# forward environment overrides to popup sessions
+	e) session_args+=("-e" "$OPTARG") ;;
 	name)
 		OPTARG="${OPTARG:${#OPT}}"
 		if [[ ${OPTARG::1} == '=' ]]; then
@@ -62,7 +64,7 @@ else
 	eval "tmux -C \; $(showhook @popup-before-open) >/dev/null"
 	tmux popup "${popup_args[@]}" "
 		tmux -L '$socket_name' \
-			new -As '$popup_id' $(escape "${cmd[@]}") \; \
+			new -As '$popup_id' ${session_args[*]} $(escape "${cmd[@]}") \; \
 			set @__popup_opened '$name' \; \
 			$(showhook @popup-on-init "$DEFAULT_ON_INIT") \; \
 			>/dev/null"


### PR DESCRIPTION
As mentioned in <https://github.com/loichyan/tmux-toggle-popup/pull/5#issuecomment-2415237970>, environment overrides are not set properly in opened popups. This is because commands actually start inside a tmux session, which is typically running in a standalone tmux instance, so environment overrides in `display-popup -e KEY=value` are not set in the attached tmux session unless we explicitly forward them to `new-session -e KEY=value`.