### PR TITLE
feat!: improve hooks parsing and escaping

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A handy plugin that helps create toggleable popups.
 <br>
 
 - DE: [Gnome 46](https://release.gnome.org/46) & [PaperWM](https://github.com/paperwm/PaperWM)
-- Tmux: [Catppuccin theme](https://github.com/catppuccin/tmux)
+- tmux: [Catppuccin theme](https://github.com/catppuccin/tmux)
 - Font: [Rec Mono Duotone](https://www.recursive.design)
 - Keystrokes: [Show Me the Key](https://showmethekey.alynx.one)
 - Rickroll: [rickrollrc](https://github.com/keroserene/rickrollrc)
@@ -24,9 +24,9 @@ for more details_
 
 ### Requirements
 
-- Tmux >= **3.4** (not tested on earlier versions)
+- tmux >= **3.4** (not tested on earlier versions)
 
-### With [Tmux Plugin Manager](https://github.com/tmux-plugins/tpm) (recommended)
+### With [tmux Plugin Manager](https://github.com/tmux-plugins/tpm) (recommended)
 
 Add this plugin to the list of TPM plugins in `.tmux.conf`:
 
@@ -48,7 +48,7 @@ Add this line to the bottom of `.tmux.conf`:
 run ~/clone/path/toggle-popup.tmux
 ```
 
-Reload Tmux environment with: `tmux source-file ~/.tmux.conf`. You should now be able to use the
+Reload tmux environment with: `tmux source-file ~/.tmux.conf`. You should now be able to use the
 plugin.
 
 ## ✍️ Usage
@@ -104,14 +104,16 @@ format string.
 
 ## 🪝 Hooks
 
-A hook consists of Tmux commands delimited by semicolons (`;`). Each hook is interpreted by bash(1)
-as a sequence of shell arguments, which are then passed to tmux(1). Hence, semicolons should be
-escaped (`\;`) or quoted (`";"`) to prevent them from being recognized as bash command delimiters.
-Each command can alternatively be delimited by a line break, which is substituted with `\;` before
-interpretation.
+A hook consists of tmux commands. To write hooks, we support a limited version of `.tmux.conf`.
 
-A hook will be executed either in the caller (i.e., the session that calls `@popup-toggle`) or in
-the popup (i.e., the session that opens as a popup).
+To elaborate further, each tmux command can be delimited by semicolons (`;`) or line breaks. You can
+use escaped spaces (`\ `) or quotes (either `'` or `"`) to prevent an individual argument from being
+split. Additionally, you can nest different types of quotes within one another. Any character
+preceded by a backslash (`\`) is treated as a literal escape, meaning that `\;` is interpreted as
+`;`. To input `\;`, you need to escape the backslash, using `\\;`.
+
+A hook will be executed either in the caller session (i.e., the session that calls `@popup-toggle`)
+or in the popup session (i.e., the session where a popup resides).
 
 **Example**:
 
@@ -120,29 +122,33 @@ set -g @popup-on-init '
   set exit-empty off
   set status off
 '
-# Escaping "\;" is required when binding key to multiple commands
+# Bind to multiple commands should be escaped,
 set -g @popup-on-init '
-  bind M-r display "some text" \\\; display "another text"
+  bind -n M-1 display random\ text \\; display and\ more
 '
+# or quoted
+set -g @popup-on-init "
+  bind -n M-2 \"display 'random text' ; display 'and more'\"
+"
 ```
 
 ### `@popup-on-init`
 
 **Default**: `set exit-empty off \; set status off`
 
-**Description**: Tmux commands executed in the popup each time after it is opened.
+**Description**: tmux commands executed in the popup each time after it is opened.
 
 ### `@popup-before-open`
 
 **Default**: empty
 
-**Description**: Tmux commands executed in the caller each time before a popup is opened.
+**Description**: tmux commands executed in the caller each time before a popup is opened.
 
 ### `@popup-after-close`
 
 **Default**: empty
 
-**Description**: Tmux commands executed in the caller each time after a popup is closed.
+**Description**: tmux commands executed in the caller each time after a popup is closed.
 
 ## ⌨️ Keybindings
 

--- a/scripts/focus.sh
+++ b/scripts/focus.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
 # shellcheck source=./helpers.sh
 source "$CURRENT_DIR/helpers.sh"
 

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -36,7 +36,7 @@ showvariable() {
 }
 
 # Parses the tmux script into sequences and escapes each one, ensuring they can
-# be safely interrupted by Bash.
+# be safely interpreted by Bash.
 makecmds() {
 	xargs printf "%q "
 }

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -1,10 +1,5 @@
 #!/usr/bin/env bash
 
-# Concats multiline Tmux commands into a single line.
-joincmd() {
-	sed 's/$/ \\;/' | tr '\n' ' '
-}
-
 # Escapes all given arguments.
 escape() {
 	if [[ $# -gt 0 ]]; then
@@ -40,13 +35,13 @@ showvariable() {
 	tmux show -qv "$1"
 }
 
-# Returns the specified option as a hook, which consists of a sequence of Tmux
-# commands.
-showhook() {
-	showopt "$@" | joincmd
+# Parses the tmux script into sequences and escapes each one, ensuring they can
+# be safely interrupted by Bash.
+makecmds() {
+	xargs printf "%q "
 }
 
-# Expand the provided Tmux FORMAT string. The last argument is the format
+# Expand the provided tmux FORMAT string. The last argument is the format
 # string, while the preceding ones represent variables available during the
 # expansion.
 format() {

--- a/scripts/toggle.sh
+++ b/scripts/toggle.sh
@@ -7,7 +7,7 @@ source "$CURRENT_DIR/helpers.sh"
 # shellcheck source=./variables.sh
 source "$CURRENT_DIR/variables.sh"
 
-declare name popup_args session_args cmd OPT OPTARG OPTIND=1
+declare name popup_args session_args prog OPT OPTARG OPTIND=1
 
 while getopts :-:BCEb:c:d:e:h:s:S:t:T:w:x:y: OPT; do
 	if [[ $OPT == '-' ]]; then OPT="${OPTARG%%=*}"; fi
@@ -55,7 +55,7 @@ while getopts :-:BCEb:c:d:e:h:s:S:t:T:w:x:y: OPT; do
 	*) badopt ;;
 	esac
 done
-cmd=("${@:$OPTIND}")
+prog=("${@:$OPTIND}")
 
 # If the specified name doesn't match the currently opened popup, we open a new
 # popup within the current one (i.e. popup-in-popup).
@@ -70,17 +70,19 @@ fi
 name="${name:-$DEFAULT_NAME}"
 socket_name="${socket_name:-$(get_socket_name)}"
 id_format="${id_format:-$(showopt @popup-id-format "$DEFAULT_ID_FORMAT")}"
-on_init="${on_init:-$(showhook @popup-on-init "$DEFAULT_ON_INIT")}"
-before_open="${before_open:-$(showhook @popup-before-open)}"
-after_close="${after_close:-$(showhook @popup-after-close)}"
+on_init="${on_init:-$(showopt @popup-on-init "$DEFAULT_ON_INIT")}"
+before_open="${before_open:-$(showopt @popup-before-open)}"
+after_close="${after_close:-$(showopt @popup-after-close)}"
 
 popup_id="$(format @popup_name "$name" "$id_format")"
 
-eval "tmux -C \; $before_open >/dev/null"
-tmux popup "${popup_args[@]}" "
-		TMUX_POPUP_SERVER='$socket_name' tmux -L '$socket_name' \
-			new -As '$popup_id' $(escape "${session_args[@]}") $(escape "${cmd[@]}") \; \
-			set @__popup_opened '$name' \; \
-			$on_init \; \
-			>/dev/null"
-eval "tmux -C \; $after_close >/dev/null"
+eval "tmux -C $(echo "$before_open" | makecmds) >/dev/null"
+tmux popup "${popup_args[@]}" \
+	"TMUX_POPUP_SERVER='$socket_name' tmux -L '$socket_name' $(
+		cat <<-EOF | makecmds
+			new -As '$popup_id' $(escape "${session_args[@]}") $(escape "${prog[@]}") ;
+			set @__popup_opened '$name' ;
+			$on_init ;
+		EOF
+	) >/dev/null"
+eval "tmux -C $(echo "$after_close" | makecmds) >/dev/null"

--- a/scripts/toggle.sh
+++ b/scripts/toggle.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
 # shellcheck source=./helpers.sh
 source "$CURRENT_DIR/helpers.sh"
 # shellcheck source=./variables.sh

--- a/scripts/toggle.sh
+++ b/scripts/toggle.sh
@@ -75,7 +75,9 @@ after_close="${after_close:-$(showopt @popup-after-close)}"
 
 popup_id="$(format @popup_name "$name" "$id_format")"
 
-eval "tmux -C $(echo "$before_open" | makecmds) >/dev/null"
+if [[ -n $before_open ]]; then
+	eval "tmux -C $(echo "$before_open" | makecmds) >/dev/null"
+fi
 tmux popup "${popup_args[@]}" \
 	"TMUX_POPUP_SERVER='$socket_name' tmux -L '$socket_name' $(
 		cat <<-EOF | makecmds
@@ -84,4 +86,6 @@ tmux popup "${popup_args[@]}" \
 			$on_init ;
 		EOF
 	) >/dev/null"
-eval "tmux -C $(echo "$after_close" | makecmds) >/dev/null"
+if [[ -n $after_close ]]; then
+	eval "tmux -C $(echo "$after_close" | makecmds) >/dev/null"
+fi

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -4,7 +4,7 @@
 DEFAULT_NAME='default'
 DEFAULT_SOCKET_NAME='popup'
 DEFAULT_ID_FORMAT='#{b:socket_path}/#{session_name}/#{b:pane_current_path}/#{@popup_name}'
-DEFAULT_ON_INIT="set exit-empty off \; set status off"
+DEFAULT_ON_INIT="set exit-empty off ; set status off"
 
 get_socket_name() {
 	showopt @popup-socket-name "$DEFAULT_SOCKET_NAME"

--- a/tests.sh
+++ b/tests.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+for test in ./tests/*; do
+	echo "run test: $test"
+	command "$test"
+done

--- a/tests/commands-parser.sh
+++ b/tests/commands-parser.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../scripts//helpers.sh
+source "$CURRENT_DIR/../scripts/helpers.sh"
+
+test_fail() {
+	echo "${BASH_SOURCE[1]}:${BASH_LINENO[1]}" "$@"
+	exit 1
+}
+
+# Simulates Bash arguments interpretation.
+reparse_commands() {
+	# shellcheck disable=2046
+	eval printf '%s\\n' $(cat)
+}
+
+test_parse_commands() {
+	readarray -t commands < <(echo "$1" | makecmds | reparse_commands)
+	shift
+
+	if [[ $# -ne ${#commands[@]} ]]; then
+		test_fail "expected $# commands to be parsed, got \`$(printf "%s, " "${commands[@]}")\`"
+	fi
+
+	local -i i=0
+	while [[ $# -gt 0 ]]; do
+		if [[ $1 != "${commands[$i]}" ]]; then
+			git diff <(echo "$1") <(echo "${commands[i]}")
+			test_fail "unexpected command at $((i + 1))"
+		fi
+		shift
+		i+=1
+	done
+}
+
+# delimited by `;`
+test_parse_commands \
+	'set status off ; set exit-empty off' \
+	'set' 'status' 'off' ';' \
+	'set' 'exit-empty' 'off'
+# delimited by line breaks
+test_parse_commands \
+	'set status off
+	 set exit-empty off' \
+	'set' 'status' 'off' \
+	'set' 'exit-empty' 'off'
+# escaped multiple commands
+test_parse_commands \
+	'bind -n M-1 display random\ text \\; display and\ more' \
+	'bind' '-n' 'M-1' \
+	'display' 'random text' '\;' \
+	'display' 'and more'
+# quoted multiple commands
+test_parse_commands \
+	"bind -n M-2 \"display 'random text' ; display 'and more'\"" \
+	'bind' '-n' 'M-2' \
+	"display 'random text' ; display 'and more'"

--- a/toggle-popup.tmux
+++ b/toggle-popup.tmux
@@ -15,7 +15,8 @@ set_keybindings() {
 
 handle_autostart() {
 	# shellcheck disable=2155
-	if [[ -z $TMUX_POPUP_SERVER ]]; then
+	# do not start itself within a popup server
+	if [[ $(showopt @popup-autostart) == "on" && -z $TMUX_POPUP_SERVER ]]; then
 		# set $TMUX_POPUP_SERVER, used to identify the popup server
 		local socket_name="$(get_socket_name)"
 		TMUX_POPUP_SERVER="$socket_name" tmux -L "$socket_name" new -d &


### PR DESCRIPTION
Currently, we use Bash to interpret tmux commands through `eval tmux <commands>`. This method is generally unsafe and may introduce mental overhead due to syntax differences between Bash and tmux (e.g., a session name like `$aaa` may be expanded as a variable in Bash). This PR introduces a new parser for a more robust solution. 

Internally, we use `xargs` to parse arguments into sequences and `printf %q` to escape each one. This allows users to input `;` directly as the command delimiter without worrying about Bash's interpretation. For the precisely supported syntax, please refer to the updated README.

Additionally, this PR adds the missing parse process for the `--on-init`, `--before-open`, and `--after-close` arguments in `@popup-toggle`. @cenk1cenk2, the `tmux_escape(...)` function may no longer be needed in [your plugin](https://github.com/loichyan/tmux-toggle-popup.nvim), and you can directly pass user-defined hooks to `@popup-toggle` :P

**BREAKING CHANGE**: The new parser may produce results that differ from the previous version.BREAKING CHANGE: The new parser may produce results that differ from the previous version.