### PR TITLE
fix: respect the user's `@popup-autostart` setting

### DIFF
--- a/toggle-popup.tmux
+++ b/toggle-popup.tmux
@@ -15,7 +15,8 @@ set_keybindings() {
 
 handle_autostart() {
 	# shellcheck disable=2155
-	if [[ -z $TMUX_POPUP_SERVER ]]; then
+	# do not start itself within a popup server
+	if [[ $(showopt @popup-autostart) == "on" && -z $TMUX_POPUP_SERVER ]]; then
 		# set $TMUX_POPUP_SERVER, used to identify the popup server
 		local socket_name="$(get_socket_name)"
 		TMUX_POPUP_SERVER="$socket_name" tmux -L "$socket_name" new -d &


### PR DESCRIPTION
Fixes #10. Brings the check for the `@popup-autostart` option back, which was unexpectedly removed in [@d95d654f](https://github.com/loichyan/tmux-toggle-popup/commit/d95d654f3eee8f1b9e86ebc000a9718305a442ce).