### PR TITLE
fix: ensure popup commands are interpreted by sh

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -25,8 +25,8 @@ badopt() {
 # Returns the value of the specified option or the second argument as the
 # fallback value if the option is empty.
 showopt() {
-	local v
-	v="$(tmux show -gqv "$1")"
+	# shellcheck disable=2155
+	local v="$(tmux show -gqv "$1")"
 	echo "${v:-"$2"}"
 }
 

--- a/scripts/toggle.sh
+++ b/scripts/toggle.sh
@@ -101,15 +101,20 @@ if [[ -n $before_open ]]; then
 	eval "tmux -C $(echo "$before_open" | makecmds) >/dev/null"
 fi
 # hook: on-init
-# printf "debug: %s\n" \
-tmux popup "${popup_args[@]}" \
+# Temporarily change `default-shell` to `/bin/sh` so that our scripts can be
+# recognized correctly.
+default_shell="$(get_default_shell)"
+tmux \
+	set default-shell /bin/sh \; \
+	popup "${popup_args[@]}" \
 	"TMUX_POPUP_SERVER='$socket_name' tmux -L '$socket_name' $(
 		cat <<-EOF | makecmds
 			new -As '$popup_id' $(escape "${session_args[@]}") $(escape "${prog[@]}") ;
 			set @__popup_opened '$name' ;
 			${on_init[*]} ;
 		EOF
-	) >/dev/null"
+	) >/dev/null" \; \
+	set default-shell "$default_shell"
 # keybindings are registered to the global server level
 if [[ ${#unbind_keys[@]} -gt 0 ]]; then
 	# the tmux server may have stopped, ignore the returned error

--- a/scripts/toggle.sh
+++ b/scripts/toggle.sh
@@ -107,7 +107,7 @@ default_shell="$(get_default_shell)"
 tmux \
 	set default-shell /bin/sh \; \
 	popup "${popup_args[@]}" \
-	"TMUX_POPUP_SERVER='$socket_name' tmux -L '$socket_name' $(
+	"TMUX_POPUP_SERVER='$socket_name' SHELL='$default_shell' tmux -L '$socket_name' $(
 		cat <<-EOF | makecmds
 			new -As '$popup_id' $(escape "${session_args[@]}") $(escape "${prog[@]}") ;
 			set @__popup_opened '$name' ;

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -9,3 +9,7 @@ DEFAULT_ON_INIT="set exit-empty off ; set status off"
 get_socket_name() {
 	showopt @popup-socket-name "$DEFAULT_SOCKET_NAME"
 }
+
+get_default_shell() {
+	showopt default-shell "$SHELL"
+}

--- a/toggle-popup.tmux
+++ b/toggle-popup.tmux
@@ -19,7 +19,10 @@ handle_autostart() {
 	if [[ $(showopt @popup-autostart) == "on" && -z $TMUX_POPUP_SERVER ]]; then
 		# set $TMUX_POPUP_SERVER, used to identify the popup server
 		local socket_name="$(get_socket_name)"
-		TMUX_POPUP_SERVER="$socket_name" tmux -L "$socket_name" new -d &
+		# propagate user's default shell
+		local default_shell="$(get_default_shell)"
+		TMUX_POPUP_SERVER="$socket_name" SHELL="$default_shell" \
+			tmux -L "$socket_name" set exit-empty off \; start &
 	fi
 }
 


### PR DESCRIPTION
tmux 3.5 and 3.5a introduce some changes to the default shell used for executing commands in `display-popup` [^1] [^2] [^3]. Our scripts are written in `sh`, which means if users employ a shell that is incompatible with `sh` syntax, such as `fish`, these commands may not be recognized correctly. This PR ensures tmux uses `/bin/sh` to execute popup commands and also properly propagates the user's `default-shell` option to the popup server, as the aforementioned upstream updates change `$SHELL` to `/bin/sh`.

[^1]: tmux/tmux@f95d055e04f129b015a46deb702081b8b87636ca
[^2]: tmux/tmux@d39dcea30ad2814a70a1f65e43468a78df4df8e5
[^3]: tmux/tmux#4162