### PR TITLE
fix: do not clear the popup opened flag before detaching

### DIFF
--- a/scripts/toggle.sh
+++ b/scripts/toggle.sh
@@ -71,9 +71,7 @@ prog=("${@:$OPTIND}")
 # popup within the current one (i.e., popup-in-popup).
 opened_name="$(showvariable @__popup_opened)"
 if [[ -n $opened_name && ($name == "$opened_name" || -n $force || -z $*) ]]; then
-	# Clear the variables to prevent a manually attached session from being
-	# detached by the keybinding.
-	tmux set -u @__popup_opened \; detach
+	tmux detach
 	exit 0
 fi
 


### PR DESCRIPTION
If a popup is opened twice, the first toggle call may render the subsequent toggle call in another client ineffective, as it clears the popup opened flag.