### PR TITLE
fix: improve workarounds for default shell of popups

### DIFF
--- a/scripts/really-open.sh
+++ b/scripts/really-open.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# execute the open script if exists
+if [ -n "$__tmux_popup_open" ]; then
+	eval exec "$__tmux_popup_open"
+else
+	exec "$SHELL" "$@"
+fi

--- a/scripts/really-open.sh
+++ b/scripts/really-open.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
-# execute the open script if exists
-if [ -n "$__tmux_popup_open" ]; then
-	eval exec "$__tmux_popup_open"
+# clear the temporary variable
+open_script="${__tmux_popup_open:-}"
+unset -v __tmux_popup_open
+if [ -n "$open_script" ]; then
+	# execute the open script if exists
+	eval exec "$open_script"
 else
+	# or fallback to user's default shell
 	exec "$SHELL" "$@"
 fi


### PR DESCRIPTION
I’m not sure if this will resolve the hanging issue reported in https://github.com/loichyan/tmux-toggle-popup/pull/15#issuecomment-2424160328, but since we do not reattach to the working session at all, it may improve the situation. 

To elaborate further, instead of changing the user's `default-shell`, we put the entire open script in a temporary env variable and call `./really-open.sh` to execute these commands. This approach only requires the user's default shell to support the `exec` command, which I believe most shells do.