### PR TITLE
chore(release): v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
 
-## [Unreleased]
+## [v0.3.0](https://github.com/loichyan/tmux-toggle-popup/compare/v0.2.0..v0.3.0) - 2024-10-21
 
 ### ⚠️ Breaking Changes
 
@@ -12,6 +12,51 @@ All notable changes to this project will be documented in this file. See [conven
 
 - We've implemented several improvements to make it easier for other programs to integrate with this plugin ([#5](https://github.com/loichyan/tmux-toggle-popup/pull/5), [#9](https://github.com/loichyan/tmux-toggle-popup/pull/9)). You can now override popup global options on the fly using the newly added arguments for `@popup-toggle`.
 - This release also includes some fixes to address the changes in `display-popup` introduced in tmux versions 3.5 and 3.5a ([#14](https://github.com/loichyan/tmux-toggle-popup/pull/14)).
+
+### ⛰️ Features
+
+- [**breaking**] Support bind additional toggle keys in popups - @loichyan - [#9](https://github.com/loichyan/tmux-toggle-popup/pull/9)
+- [**breaking**] Improve hooks parsing and escaping - @loichyan - [#8](https://github.com/loichyan/tmux-toggle-popup/pull/8)
+- Support override global options through the toggle script - @cenk1cenk2 - [#5](https://github.com/loichyan/tmux-toggle-popup/pull/5)
+- Set a env variable to identify popup servers - @loichyan - [d95d654](https://github.com/loichyan/tmux-toggle-popup/commit/d95d654f3eee8f1b9e86ebc000a9718305a442ce)
+- Support autostart popup server - @loichyan - [13bb98a](https://github.com/loichyan/tmux-toggle-popup/commit/13bb98a31debe4d7ca62b2f05e1401d93af53e23)
+
+### 🐛 Bug Fixes
+
+- Improve workarounds for default shell of popups - @loichyan - [#17](https://github.com/loichyan/tmux-toggle-popup/pull/17)
+- Do not clear the popup opened flag before detaching - @loichyan - [#16](https://github.com/loichyan/tmux-toggle-popup/pull/16)
+- Revert to `default-shell` promptly - @loichyan - [#15](https://github.com/loichyan/tmux-toggle-popup/pull/15)
+- Propagate user's default shell to popup servers - @loichyan - [c662850](https://github.com/loichyan/tmux-toggle-popup/commit/c6628500e001997bbd8c45442cea5ed3d1d9b204)
+- Ensure popup commands are interpreted by sh - @loichyan - [9d4dc82](https://github.com/loichyan/tmux-toggle-popup/commit/9d4dc82bf8b682e139cd0a2b3e91abf75ef28b4e)
+- The first argument is eaten in `xargs bash -c` - @loichyan - [d50e9d5](https://github.com/loichyan/tmux-toggle-popup/commit/d50e9d58a5431e9bff787463edb8aaec4a5caae2)
+- Try to fix Bash errors on macOS - @loichyan - [9148507](https://github.com/loichyan/tmux-toggle-popup/commit/9148507d16e20768d3211555d1592ac9d88d110d)
+- Respect the user's `@popup-autostart` setting - @loichyan - [#11](https://github.com/loichyan/tmux-toggle-popup/pull/11)
+- Escape `$session_args` before passing to tmux - @cenk1cenk2 - [#7](https://github.com/loichyan/tmux-toggle-popup/pull/7)
+- Forward environment overrides to popup sessions - @loichyan - [#6](https://github.com/loichyan/tmux-toggle-popup/pull/6)
+- Always retrieve option values from global - @loichyan - [61789c7](https://github.com/loichyan/tmux-toggle-popup/commit/61789c7b22fc6428a3248575503d65d88841de73)
+
+### 📚 Documentation
+
+- Use git-cliff to generate changelogs - @loichyan - [#18](https://github.com/loichyan/tmux-toggle-popup/pull/18)
+- Fix wrong default value of `@popup-on-init` - @loichyan - [4190348](https://github.com/loichyan/tmux-toggle-popup/commit/4190348f56bafbfb74d0e4ef779bce22f94c44a6)
+- Move examples after descriptions - @loichyan - [f262873](https://github.com/loichyan/tmux-toggle-popup/commit/f26287301f3e1a6a9c747e4170102114b3d44265)
+- Display shorter links - @loichyan - [631d208](https://github.com/loichyan/tmux-toggle-popup/commit/631d20835269e1bf15abfdccde6477e19dcfb6cd)
+- Update README - @loichyan - [95db7e1](https://github.com/loichyan/tmux-toggle-popup/commit/95db7e1108336576b82a90e57346eec25e1b7c43)
+- Fix wrong issue ID - @loichyan - [6b45025](https://github.com/loichyan/tmux-toggle-popup/commit/6b45025101aa047ad470f28ac3bb33f6fc7c2932)
+
+### 🚜 Refactor
+
+- Use `==` in bash conditions - @loichyan - [4ab9467](https://github.com/loichyan/tmux-toggle-popup/commit/4ab946735ca4c67869825cadc7b70673d4500167)
+- Always use Bash's condition syntax - @loichyan - [397038e](https://github.com/loichyan/tmux-toggle-popup/commit/397038e5cbbca5d5d1d3ca246ccd0c2e33554df2)
+
+### ⚙️ Miscellaneous Tasks
+
+- Auto release with GitHub Actions - @loichyan - [#19](https://github.com/loichyan/tmux-toggle-popup/pull/19)
+- Set up GitHub Actions to run tests - @loichyan - [cb93148](https://github.com/loichyan/tmux-toggle-popup/commit/cb93148f70764842c30926c665849bd5ede507ba)
+
+### ❤️ New Contributors
+
+- @cenk1cenk2 made their first contribution in [#7](https://github.com/loichyan/tmux-toggle-popup/pull/7)
 
 ## [v0.2.0](https://github.com/loichyan/tmux-toggle-popup/compare/v0.1.0..v0.2.0) - 2024-06-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
 
+## [Unreleased]
+
+### ⚠️ Breaking Changes
+
+- Use xargs(1) and printf(1) to parse tmux commands ([#8](https://github.com/loichyan/tmux-toggle-popup/pull/8)). This allows users to input `;` directly as the command delimiter without worrying about Bash's interpretation. The new parser may yield results that differ from the previous version, although this is usually not the case.
+
+### ✨ Highlights
+
+- We've implemented several improvements to make it easier for other programs to integrate with this plugin ([#5](https://github.com/loichyan/tmux-toggle-popup/pull/5), [#9](https://github.com/loichyan/tmux-toggle-popup/pull/9)). You can now override popup global options on the fly using the newly added arguments for `@popup-toggle`.
+- This release also includes some fixes to address the changes in `display-popup` introduced in tmux versions 3.5 and 3.5a ([#14](https://github.com/loichyan/tmux-toggle-popup/pull/14)).
+
 ## [v0.2.0](https://github.com/loichyan/tmux-toggle-popup/compare/v0.1.0..v0.2.0) - 2024-06-05
 
 ### ⚠️ Breaking Changes

--- a/cliff.toml
+++ b/cliff.toml
@@ -4,6 +4,7 @@
 [remote.github]
 owner = "loichyan"
 repo = "tmux-toggle-popup"
+# version = "v0.3.0"
 
 [git]
 # parse the commits based on https://www.conventionalcommits.org


### PR DESCRIPTION
### ⚠️ Breaking Changes

- Use xargs(1) and printf(1) to parse tmux commands ([#8](https://github.com/loichyan/tmux-toggle-popup/pull/8)). This allows users to input `;` directly as the command delimiter without worrying about Bash's interpretation. The new parser may yield results that differ from the previous version, although this is usually not the case.

### ✨ Highlights

- We've implemented several improvements to make it easier for other programs to integrate with this plugin ([#5](https://github.com/loichyan/tmux-toggle-popup/pull/5), [#9](https://github.com/loichyan/tmux-toggle-popup/pull/9)). You can now override popup global options on the fly using the newly added arguments for `@popup-toggle`.
- This release also includes some fixes to address the changes in `display-popup` introduced in tmux versions 3.5 and 3.5a ([#14](https://github.com/loichyan/tmux-toggle-popup/pull/14)).