### PR TITLE
feat!: support switch popups when toggled

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,29 +175,29 @@ necessary adjustments. You can also specify a different key table using `--toggl
 `--toggle '-Troot M-t'`.
 
 ```text
-USAGE:
+Usage:
 
-  toggle.sh [OPTION]... [SHELL_COMMAND]...
+  toggle.sh [OPTIONS] [POPUP_OPTIONS] [SHELL_COMMAND]...
 
-OPTIONS:
+Options:
 
-  --name <name>               Popup name. [Default: "default"]
-  --force                     Toggle the popup even if its name doesn't match.
-  --toggle-key <key>          Bind additional keys to close the opened popup.
-  -[BCE]                      Flags passed to display-popup.
-  -[bcdehsStTwxy] <value>     Options passed to display-popup.
+  --name <name>               Popup name [Default: "default"]
+  --force                     Toggle the popup even if its name doesn't match
+  --toggle-key <key>          Bind additional keys to close the opened popup
+  -[BCE]                      Flags passed to display-popup
+  -[bcdehsStTwxy] <value>     Options passed to display-popup
 
-POPUP OPTIONS:
+Popup Options:
 
   Override global popup options on the fly.
 
-  --socket-name <value>       Socket name.
-  --id-format <value>         Popup ID format.
-  --on-init <hook>            Command to run on popup initialization.
-  --before-open <hook>        Hook to run before opening the popup.
-  --after-close <hook>        Hook to run after closing the popup.
+  --socket-name <value>       Socket name
+  --id-format <value>         Popup ID format
+  --on-init <hook>            Command to run on popup initialization
+  --before-open <hook>        Hook to run before opening the popup
+  --after-close <hook>        Hook to run after closing the popup
 
-EXAMPLES:
+Examples:
 
   toggle.sh -Ed'#{pane_current_path}' --name=bash bash
 ```
@@ -215,16 +215,16 @@ focus events can be specified and events are sent only if the current program ma
 names; if no name is provided, focus events are always sent.
 
 ```text
-USAGE:
+Usage:
 
   focus.sh [OPTION]... [PROGRAM]...
 
-OPTIONS:
+Options:
 
-  --enter           Send focus enter event. [Default mode]
-  --leave           Send focus leave event.
+  --enter      Send focus enter event [Default mode]
+  --leave      Send focus leave event
 
-EXAMPLES:
+Examples:
 
   focus.sh --enter nvim emacs
 ```

--- a/README.md
+++ b/README.md
@@ -88,19 +88,24 @@ if '[ -n "$TMUX_POPUP_SERVER" ]' {
 
 ### `@popup-id-format`
 
-**Default**: `#{b:socket_path}/#{session_name}/#{b:pane_current_path}/#{@popup_name}`
+**Default**: `#{b:socket_path}/#{session_name}/#{b:pane_current_path}/{popup_name}`
 
 **Description**: A format string used to generate IDs for each popup, allowing you to customize how
 popups are shared across sessions, windows, and panes. By default, popups are independent across
 sessions, and in each session, popups are shared among the same project (identified by the directory
-name). A variable named `@popup_name` is assigned the name of the popup during the expansion of the
-format string.
+name). A placedholder named `{popup_name}` is substituted with the popup name during the expansion.
 
 ### `@popup-autostart`
 
 **Default**: `off`
 
 **Description**: If enabled, the designated tmux server for popups will start automatically.
+
+### `@popup-toggle-mode`
+
+**Default**: `switch`
+
+**Description**: The default toggle mode of `@popup-toggle`.
 
 ## 🪝 Hooks
 
@@ -154,14 +159,14 @@ set -g @popup-on-init "
 
 ### `@popup-toggle`
 
-**Description**: A shell script to toggle a popup: when invoked in a popup of the same name, it
-closes the popup; otherwise, it opens a popup of the specified name. If no argument is passed or
-`--force` is specified and called in a popup, it will close the popup.
+**Description**: A shell script to toggle a popup. When invoked in your working session, it opens a
+reusable popup window identified by `--name`. It supports three modes to handle nested toggle calls,
+specifically when invoked in an opened popup with a different name specified:
 
-By default, if you call it with the name _A_ specified within another opened popup _B_, it will open
-a new popup _A_ inside _B_ instead of closing _B_ (i.e., popup-in-popup). You may find this behavior
-surprising, but tmux simply allows us to do so. This can be prevented by the `--force` flag. Or you
-can bind `run "#{@popup-toggle}"` to a primary toggle key, which will close the opened popup anyway.
+1. `switch`: The default mode. Keep the popup window open and switch to the new popup.
+2. `force-close`: Close the opened popup window. This is the expected behavior when the name matches
+   or no arguments are provided.
+3. `force-open`: Open a new popup window within the current one, i.e., popup-in-popup.
 
 If you have set popup keybindings in your `.tmux.conf`, which should be loaded in both your default
 server and the popup server, there's no need to worry about the toggle keys. For instance, if `M-t`
@@ -182,7 +187,7 @@ Usage:
 Options:
 
   --name <name>               Popup name [Default: "default"]
-  --force                     Toggle the popup even if its name doesn't match
+  --toggle-mode <mode>        Action to handle nested calls [Default: "switch"]
   --toggle-key <key>          Bind additional keys to close the opened popup
   -[BCE]                      Flags passed to display-popup
   -[bcdehsStTwxy] <value>     Options passed to display-popup

--- a/scripts/focus.sh
+++ b/scripts/focus.sh
@@ -13,16 +13,16 @@ while getopts :-: OPT; do
 	leave) mode=O ;;
 	help)
 		cat <<-EOF
-			USAGE:
+			Usage:
 
 			  focus.sh [OPTION]... [PROGRAM]...
 
-			OPTIONS:
+			Options:
 
-			  --enter           Send focus enter event. [Default mode]
-			  --leave           Send focus leave event.
+			  --enter      Send focus enter event [Default mode]
+			  --leave      Send focus leave event
 
-			EXAMPLES:
+			Examples:
 
 			  focus.sh --enter nvim emacs
 		EOF

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -44,15 +44,20 @@ makecmds() {
 	xargs bash -c 'printf "%q " "$@"' _
 }
 
-# Expand the provided tmux FORMAT string. The last argument is the format
-# string, while the preceding ones represent variables available during the
-# expansion.
+# Expands the provided tmux FORMAT string.
 format() {
-	local set_v=() unset_v=()
+	tmux display -p "$*"
+}
+
+# Interpolates the provided FORMAT string. The last argument is the format
+# string, while the preceding arguments represent the variables available during
+# the expansion. All `{variable}` placeholders in the format string will be
+# replaced with their corresponding values.
+interpolate() {
+	local result="${*: -1}"
 	while [[ $# -gt 1 ]]; do
-		set_v+=(set "$1" "$2" \;)
-		unset_v+=(set -u "$1" \;)
+		result="${result//"{$1}"/$2}"
 		shift 2
 	done
-	tmux "${set_v[@]}" display -p "$*" \; "${unset_v[@]}"
+	echo "$result"
 }

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -41,7 +41,7 @@ makecmds() {
 	# Force to use bash's bulitin printf as macOS's printf does not support "%q".
 	# The first argument to `bash -c` is the script name, so we need a dummy
 	# name to prevent it from being "eaten" by Bash.
-	xargs bash -c 'printf "%q " "$@"' _
+	echo "$*" | xargs bash -c 'printf "%q " "$@"' _
 }
 
 # Expands the provided tmux FORMAT string.

--- a/scripts/really-open.sh
+++ b/scripts/really-open.sh
@@ -4,7 +4,7 @@ open_script="${__tmux_popup_open:-}"
 unset -v __tmux_popup_open
 if [ -n "$open_script" ]; then
 	# execute the open script if exists
-	eval exec "$open_script"
+	eval "$open_script"
 else
 	# or fallback to user's default shell
 	exec "$SHELL" "$@"

--- a/scripts/toggle.sh
+++ b/scripts/toggle.sh
@@ -114,7 +114,7 @@ fi
 # hook: before-open
 before_open="${before_open:-$(showopt @popup-before-open)}"
 if [[ -n $before_open ]]; then
-	eval "tmux -C $(makecmds "$before_open") >/dev/null"
+	eval "tmux -C $(makecmds "$before_open")" >/dev/null
 fi
 
 # expand the configured ID format
@@ -122,7 +122,7 @@ id_format="$(format "${id_format:-$(showopt @popup-id-format "$DEFAULT_ID_FORMAT
 open_args+=("-A") # create the target session and attach to it
 prepare_for_open
 socket_name="${socket_name:-$(get_socket_name)}"
-open_script="tmux -L '$socket_name' $open_cmds >/dev/null"
+open_script="tmux -L '$socket_name' $open_cmds"
 
 # Starting from version 3.5, tmux uses the user's `default-shell` to execute
 # shell commands. However, our scripts are written in `sh`, which may not be
@@ -138,11 +138,11 @@ tmux popup "${popup_args[@]}" \
 # undo temporary changes
 if [[ ${#on_cleanup[@]} -gt 0 ]]; then
 	# the tmux server may have stopped, ignore the returned error
-	eval "tmux -NCL '$socket_name' $(makecmds "$on_cleanup") &>/dev/null" || true
+	eval "tmux -NCL '$socket_name' $(makecmds "$on_cleanup")" &>/dev/null || true
 fi
 
 # hook: after-close
 after_close="${after_close:-$(showopt @popup-after-close)}"
 if [[ -n $after_close ]]; then
-	eval "tmux -C $(makecmds "$after_close") >/dev/null"
+	eval "tmux -C $(makecmds "$after_close")" >/dev/null
 fi

--- a/scripts/toggle.sh
+++ b/scripts/toggle.sh
@@ -104,7 +104,7 @@ if [[ -n $opened_name ]]; then
 		id_format="$(showvariable @__popup_id_format)"
 		open_args+=("-d") # create the target session if not exists
 		prepare_for_open
-		eval tmux "$open_cmds" >/dev/null
+		eval tmux -C "$open_cmds" >/dev/null
 		exec tmux switch -t "$popup_id"
 	elif [[ $toggle_mode != "force-open" ]]; then
 		die "illegal toggle mode: $toggle_mode"

--- a/scripts/toggle.sh
+++ b/scripts/toggle.sh
@@ -34,29 +34,29 @@ while getopts :-:BCEb:c:d:e:h:s:S:t:T:w:x:y: OPT; do
 	force) declare "${OPT/-/_}"="1" ;;
 	help)
 		cat <<-EOF
-			USAGE:
+			Usage:
 
-			  toggle.sh [OPTION]... [SHELL_COMMAND]...
+			  toggle.sh [OPTIONS] [POPUP_OPTIONS] [SHELL_COMMAND]...
 
-			OPTIONS:
+			Options:
 
-			  --name <name>               Popup name. [Default: "$DEFAULT_NAME"]
-			  --force                     Toggle the popup even if its name doesn't match.
-			  --toggle-key <key>          Bind additional keys to close the opened popup.
-			  -[BCE]                      Flags passed to display-popup.
-			  -[bcdehsStTwxy] <value>     Options passed to display-popup.
+			  --name <name>               Popup name [Default: "$DEFAULT_NAME"]
+			  --force                     Toggle the popup even if its name doesn't match
+			  --toggle-key <key>          Bind additional keys to close the opened popup
+			  -[BCE]                      Flags passed to display-popup
+			  -[bcdehsStTwxy] <value>     Options passed to display-popup
 
-			POPUP OPTIONS:
+			Popup Options:
 
 			  Override global popup options on the fly.
 
-			  --socket-name <value>       Socket name. [Default: "$DEFAULT_SOCKET_NAME"]
-			  --id-format <value>         Popup ID format. [Default: "$DEFAULT_ID_FORMAT"]
-			  --on-init <hook>            Command to run on popup initialization. [Default: "$DEFAULT_ON_INIT"]
-			  --before-open <hook>        Hook to run before opening the popup. [Default: ""]
-			  --after-close <hook>        Hook to run after closing the popup. [Default: ""]
+			  --socket-name <value>       Socket name [Default: "$DEFAULT_SOCKET_NAME"]
+			  --id-format <value>         Popup ID format [Default: "$DEFAULT_ID_FORMAT"]
+			  --on-init <hook>            Command to run on popup initialization [Default: "$DEFAULT_ON_INIT"]
+			  --before-open <hook>        Hook to run before opening the popup [Default: ""]
+			  --after-close <hook>        Hook to run after closing the popup [Default: ""]
 
-			EXAMPLES:
+			Examples:
 
 			  toggle.sh -Ed'#{pane_current_path}' --name=bash bash
 		EOF

--- a/scripts/toggle.sh
+++ b/scripts/toggle.sh
@@ -81,7 +81,7 @@ id_format="${id_format:-$(showopt @popup-id-format "$DEFAULT_ID_FORMAT")}"
 on_init="${on_init:-$(showopt @popup-on-init "$DEFAULT_ON_INIT")}"
 before_open="${before_open:-$(showopt @popup-before-open)}"
 after_close="${after_close:-$(showopt @popup-after-close)}"
-popup_id="$(format @popup_name "$name" "$id_format")"
+popup_id_format="$(format "$id_format")"
 
 # bind toggle keys in the opened popup
 unbind_keys=()
@@ -104,9 +104,11 @@ fi
 # put the entire script in a temporary env variable and call `./really-open.sh`
 # to run these commands. This approach only requires the user's default shell to
 # support the `exec` command, which we believe most shells do.
+popup_id="$(interpolate popup_name "$name" "$popup_id_format")"
 open_script="tmux -L '$socket_name' \
 				new -As '$popup_id' $(escape "${session_args[@]}") $(escape "${prog[@]}") \; \
 				set @__popup_opened '$name' \; \
+				set @__popup_id_format '$popup_id_format' \; \
 				$(echo "${on_init[*]}" | makecmds) \; >/dev/null"
 tmux popup "${popup_args[@]}" \
 	-e TMUX_POPUP_SERVER="$socket_name" \

--- a/scripts/toggle.sh
+++ b/scripts/toggle.sh
@@ -90,9 +90,9 @@ prepare_for_open() {
 		escape \
 			new "${open_args[@]}" -s "$popup_id" "${program[@]}" \; \
 			set @__popup_opened "$name" \; \
-			set @__popup_id_format "$id_format"
+			set @__popup_id_format "$id_format" \;
 	)"
-	open_cmds+=" \; $(makecmds "$on_init")"
+	open_cmds+="$(makecmds "$on_init")"
 }
 
 opened_name="$(showvariable @__popup_opened)"
@@ -122,7 +122,7 @@ id_format="$(format "${id_format:-$(showopt @popup-id-format "$DEFAULT_ID_FORMAT
 open_args+=("-A") # create the target session and attach to it
 prepare_for_open
 socket_name="${socket_name:-$(get_socket_name)}"
-open_script="tmux -L '$socket_name' $open_cmds"
+open_script="exec tmux -L '$socket_name' $open_cmds"
 
 # Starting from version 3.5, tmux uses the user's `default-shell` to execute
 # shell commands. However, our scripts are written in `sh`, which may not be

--- a/scripts/toggle.sh
+++ b/scripts/toggle.sh
@@ -6,7 +6,7 @@ source "$CURRENT_DIR/helpers.sh"
 # shellcheck source=./variables.sh
 source "$CURRENT_DIR/variables.sh"
 
-declare popup_args session_args toggle_keys prog OPT OPTARG OPTIND=1
+declare OPT OPTARG OPTIND=1 popup_args open_args toggle_keys
 
 while getopts :-:BCEb:c:d:e:h:s:S:t:T:w:x:y: OPT; do
 	if [[ $OPT == '-' ]]; then OPT="${OPTARG%%=*}"; fi
@@ -14,8 +14,9 @@ while getopts :-:BCEb:c:d:e:h:s:S:t:T:w:x:y: OPT; do
 	[BCE]) popup_args+=("-$OPT") ;;
 	[bcdhsStTwxy]) popup_args+=("-$OPT" "$OPTARG") ;;
 	# forward environment overrides to popup sessions
-	e) session_args+=("-e" "$OPTARG") ;;
-	name | toggle-key | socket-name | id-format | on-init | before-open | after-close)
+	e) open_args+=("-e" "$OPTARG") ;;
+	name | toggle-key | socket-name | id-format | \
+		toggle-mode | on-init | before-open | after-close)
 		OPTARG="${OPTARG:${#OPT}}"
 		if [[ ${OPTARG::1} == '=' ]]; then
 			# format: `--name=value`
@@ -31,7 +32,6 @@ while getopts :-:BCEb:c:d:e:h:s:S:t:T:w:x:y: OPT; do
 			declare "${OPT/-/_}"="$OPTARG"
 		fi
 		;;
-	force) declare "${OPT/-/_}"="1" ;;
 	help)
 		cat <<-EOF
 			Usage:
@@ -41,7 +41,7 @@ while getopts :-:BCEb:c:d:e:h:s:S:t:T:w:x:y: OPT; do
 			Options:
 
 			  --name <name>               Popup name [Default: "$DEFAULT_NAME"]
-			  --force                     Toggle the popup even if its name doesn't match
+			  --toggle-mode <mode>        Action to handle nested calls [Default: "$DEFAULT_TOGGLE_MODE"]
 			  --toggle-key <key>          Bind additional keys to close the opened popup
 			  -[BCE]                      Flags passed to display-popup
 			  -[bcdehsStTwxy] <value>     Options passed to display-popup
@@ -65,60 +65,84 @@ while getopts :-:BCEb:c:d:e:h:s:S:t:T:w:x:y: OPT; do
 	*) badopt ;;
 	esac
 done
-prog=("${@:$OPTIND}")
 
-# If the specified name doesn't match the currently opened popup, we open a new
-# popup within the current one (i.e., popup-in-popup).
-opened_name="$(showvariable @__popup_opened)"
-if [[ -n $opened_name && ($name == "$opened_name" || -n $force || -z $*) ]]; then
-	tmux detach
-	exit 0
-fi
-
+program=("${@:$OPTIND}")
 name="${name:-$DEFAULT_NAME}"
-socket_name="${socket_name:-$(get_socket_name)}"
-id_format="${id_format:-$(showopt @popup-id-format "$DEFAULT_ID_FORMAT")}"
-on_init="${on_init:-$(showopt @popup-on-init "$DEFAULT_ON_INIT")}"
-before_open="${before_open:-$(showopt @popup-before-open)}"
-after_close="${after_close:-$(showopt @popup-after-close)}"
-popup_id_format="$(format "$id_format")"
+toggle_mode="${toggle_mode:-$(showopt @popup-toggle-mode "$DEFAULT_TOGGLE_MODE")}"
 
-# bind toggle keys in the opened popup
-unbind_keys=()
-for k in "${toggle_keys[@]}"; do
-	if [[ -n $force ]]; then
-		on_init+=("; bind $k run \"#{@popup-toggle} --name='$name'\" --force")
-	else
-		on_init+=("; bind $k run \"#{@popup-toggle} --name='$name'\"")
+# Prepares the tmux commands to open a popup. When called,
+#
+# - `open_cmds` is used to create the popup session
+# - `on_cleanup` is used to undo temporary changes
+# - `popup_id` is set to the expanded popup session name
+declare open_cmds on_cleanup popup_id
+prepare_for_open() {
+	local on_init="${on_init:-$(showopt @popup-on-init "$DEFAULT_ON_INIT")}"
+
+	# create temporary toggle keys in the opened popup
+	for k in "${toggle_keys[@]}"; do
+		on_init+=" ; bind $k run \"#{@popup-toggle} --name='$name' --toggle-mode='$toggle_mode'\""
+		on_cleanup+=" ; unbind $k"
+	done
+
+	popup_id="$(interpolate popup_name "$name" "$id_format")"
+	open_cmds+="$(
+		escape \
+			new "${open_args[@]}" -s "$popup_id" "${program[@]}" \; \
+			set @__popup_opened "$name" \; \
+			set @__popup_id_format "$id_format"
+	)"
+	open_cmds+=" \; $(makecmds "$on_init")"
+}
+
+opened_name="$(showvariable @__popup_opened)"
+if [[ -n $opened_name ]]; then
+	if [[ $name == "$opened_name" || -z $* || $toggle_mode == "force-close" ]]; then
+		exec tmux detach
+	elif [[ $toggle_mode == "switch" ]]; then
+		# reuse the caller's ID format to ensure we open the intended popup
+		id_format="$(showvariable @__popup_id_format)"
+		open_args+=("-d") # create the target session if not exists
+		prepare_for_open
+		eval tmux "$open_cmds" >/dev/null
+		exec tmux switch -t "$popup_id"
+	elif [[ $toggle_mode != "force-open" ]]; then
+		die "illegal toggle mode: $toggle_mode"
 	fi
-	unbind_keys+=("; unbind $k")
-done
+fi
 
 # hook: before-open
+before_open="${before_open:-$(showopt @popup-before-open)}"
 if [[ -n $before_open ]]; then
-	eval "tmux -C $(echo "$before_open" | makecmds) >/dev/null"
+	eval "tmux -C $(makecmds "$before_open") >/dev/null"
 fi
+
+# expand the configured ID format
+id_format="$(format "${id_format:-$(showopt @popup-id-format "$DEFAULT_ID_FORMAT")}")"
+open_args+=("-A") # create the target session and attach to it
+prepare_for_open
+socket_name="${socket_name:-$(get_socket_name)}"
+open_script="tmux -L '$socket_name' $open_cmds >/dev/null"
+
 # Starting from version 3.5, tmux uses the user's `default-shell` to execute
-# shell commands. However, our scripts are written in sh, which may not be
+# shell commands. However, our scripts are written in `sh`, which may not be
 # recognized by some shells that are incompatible with it. To address this, we
 # put the entire script in a temporary env variable and call `./really-open.sh`
 # to run these commands. This approach only requires the user's default shell to
 # support the `exec` command, which we believe most shells do.
-popup_id="$(interpolate popup_name "$name" "$popup_id_format")"
-open_script="tmux -L '$socket_name' \
-				new -As '$popup_id' $(escape "${session_args[@]}") $(escape "${prog[@]}") \; \
-				set @__popup_opened '$name' \; \
-				set @__popup_id_format '$popup_id_format' \; \
-				$(echo "${on_init[*]}" | makecmds) \; >/dev/null"
 tmux popup "${popup_args[@]}" \
 	-e TMUX_POPUP_SERVER="$socket_name" \
 	-e __tmux_popup_open="$open_script" \
 	"exec $CURRENT_DIR/really-open.sh"
-if [[ ${#unbind_keys[@]} -gt 0 ]]; then
+
+# undo temporary changes
+if [[ ${#on_cleanup[@]} -gt 0 ]]; then
 	# the tmux server may have stopped, ignore the returned error
-	eval "tmux -NCL '$socket_name' $(echo "${unbind_keys[*]}" | makecmds) 2&>/dev/null" || true
+	eval "tmux -NCL '$socket_name' $(makecmds "$on_cleanup") &>/dev/null" || true
 fi
+
 # hook: after-close
+after_close="${after_close:-$(showopt @popup-after-close)}"
 if [[ -n $after_close ]]; then
-	eval "tmux -C $(echo "$after_close" | makecmds) >/dev/null"
+	eval "tmux -C $(makecmds "$after_close") >/dev/null"
 fi

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -3,7 +3,7 @@
 # shellcheck disable=2034
 DEFAULT_NAME='default'
 DEFAULT_SOCKET_NAME='popup'
-DEFAULT_ID_FORMAT='#{b:socket_path}/#{session_name}/#{b:pane_current_path}/#{@popup_name}'
+DEFAULT_ID_FORMAT='#{b:socket_path}/#{session_name}/#{b:pane_current_path}/{popup_name}'
 DEFAULT_ON_INIT="set exit-empty off ; set status off"
 
 get_socket_name() {

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -4,6 +4,7 @@
 DEFAULT_NAME='default'
 DEFAULT_SOCKET_NAME='popup'
 DEFAULT_ID_FORMAT='#{b:socket_path}/#{session_name}/#{b:pane_current_path}/{popup_name}'
+DEFAULT_TOGGLE_MODE='switch'
 DEFAULT_ON_INIT="set exit-empty off ; set status off"
 
 get_socket_name() {

--- a/tests/commands-parser.sh
+++ b/tests/commands-parser.sh
@@ -22,7 +22,7 @@ test_parse_commands() {
 	local commands=()
 	while IFS= read -r command; do
 		commands+=("$command")
-	done < <(echo "$1" | makecmds | reparse_commands)
+	done < <(makecmds "$1" | reparse_commands)
 	shift
 
 	if [[ $# -ne ${#commands[@]} ]]; then

--- a/tests/commands-parser.sh
+++ b/tests/commands-parser.sh
@@ -20,7 +20,7 @@ test_parse_commands() {
 	shift
 
 	local commands=()
-	while IFS=$'\n' read -r command; do
+	while IFS= read -r command; do
 		commands+=("$command")
 	done < <(echo "$1" | makecmds | reparse_commands)
 	shift

--- a/tests/test-helpers.sh
+++ b/tests/test-helpers.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=2155
+
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../scripts//helpers.sh
+source "$CURRENT_DIR/../scripts/helpers.sh"
+
+test_fail() {
+	echo "${BASH_SOURCE[1]}:${BASH_LINENO[1]}" "$@"
+	exit 1
+}
+
+test_interpolate() {
+	local format="$1" expected="$2"
+	local result="$(interpolate "${@:3}" "$format")"
+
+	if [[ $result != "$expected" ]]; then
+		test_fail "$result != $expected"
+	fi
+}
+
+test_interpolate \
+	"{session}/{project}/{popup_name}" \
+	"working/{project}/default" \
+	"session" "working" \
+	"popup_name" "default"
+test_interpolate \
+	"{var1}/{var2}/{var2}/{var1}" \
+	"value1/value2/value2/value1" \
+	"var1" "value1" \
+	"var2" "value2"


### PR DESCRIPTION
If the user defines many different popup key bindings, it is often the case that forcing opened popups to close or popup-in-popups is not the desired behavior to deal with nested toggle calls. This PR introduces a new toggle mode, `switch`, which allows for quick switching between open popups. Specifically, in the `switch` toggle mode, when a different popup is toggled, `@popup-toggle` will reuse the currently opened popup window and switch to the newly specified one.

BREAKING CHANGE: 

1. `@popup-toggle --force` is replaced with `--toggle-mode=force-close`. 
2. tmux variable `#{@popup_name}` in `@popup-id-format` is replaced with `{popup_name}`.