### PR TITLE
docs: update usages and format documents

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,0 @@
-{
-  "proseWrap": "always",
-  "printWidth": 120
-}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ are noticeable to end-users since the last release. For developers, this project
 
 ### Added
 
-- [**breaking**] Always place breaking changes at the top.
+- (**breaking**) Always place breaking changes at the top.
 - Append other changes in chronological order under the relevant subsections.
 
 ### Changed
@@ -41,8 +41,8 @@ are noticeable to end-users since the last release. For developers, this project
 
 ### Changed
 
-- [**breaking**] Replace `@popup-toggle --force` with `--toggle-mode=force-close` ([#21]).
-- [**breaking**] Replace tmux variable `#{@popup_name}` in `@popup-id-format` with the `{popup_name}` placeholder
+- (**breaking**) Replace `@popup-toggle --force` with `--toggle-mode=force-close` ([#21]).
+- (**breaking**) Replace tmux variable `#{@popup_name}` in `@popup-id-format` with the `{popup_name}` placeholder
   ([#21]).
 
 ### Fixed
@@ -67,7 +67,7 @@ thanks [@cenk1cenk2]). You can now override popup global options on the fly usin
 
 ### Changed
 
-- [**breaking**] Use xargs(1) and printf(1) to parse tmux commands ([#8]). This allows you to input `;` directly as the
+- (**breaking**) Use xargs(1) and printf(1) to parse tmux commands ([#8]). This allows you to input `;` directly as the
   command delimiter without worrying about Bash's interpretation. The new parser may yield results that differ from the
   previous version, although this is usually not the case.
 
@@ -95,13 +95,13 @@ thanks [@cenk1cenk2]). You can now override popup global options on the fly usin
 
 ### Changed
 
-- [**breaking**] Use bash(1) to parse tmux commands, thus semicolons in hooks (`@popup-on-open` and `@popup-on-close`)
+- (**breaking**) Use bash(1) to parse tmux commands, thus semicolons in hooks (`@popup-on-open` and `@popup-on-close`)
   must now be explicitly escaped or quoted ([#1]).
-- [**breaking**] Rename `@popup-on-open` to `@popup-on-init` ([#2]).
+- (**breaking**) Rename `@popup-on-open` to `@popup-on-init` ([#2]).
 
 ### Removed
 
-- [**breaking**] Remove `@popup-on-close`, as it cannot handle popup exits. Instead, consider setting the
+- (**breaking**) Remove `@popup-on-close`, as it cannot handle popup exits. Instead, consider setting the
   `client-detached` and `pane-exited` tmux hooks in `@popup-on-init` ([#2]).
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
-[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!--
 Here's a template for each release section. This file should only include changes that
@@ -36,14 +36,14 @@ are noticeable to end-users since the last release. For developers, this project
 
 ### Added
 
-- Add a new toggle mode, `switch`, which always reuses the currently opened window when switching to another popup
-  ([#21]).
+- Add a new toggle mode, `switch`, which always reuses the currently opened
+  window when switching to another popup ([#21]).
 
 ### Changed
 
 - (**breaking**) Replace `@popup-toggle --force` with `--toggle-mode=force-close` ([#21]).
-- (**breaking**) Replace tmux variable `#{@popup_name}` in `@popup-id-format` with the `{popup_name}` placeholder
-  ([#21]).
+- (**breaking**) Replace tmux variable `#{@popup_name}` in `@popup-id-format`
+  with the `{popup_name}` placeholder ([#21]).
 
 ### Fixed
 
@@ -54,9 +54,9 @@ are noticeable to end-users since the last release. For developers, this project
 
 ## [0.3.0] - 2024-10-21
 
-We've implemented several improvements to make it easier for other programs to integrate with this plugin ([#5], [#9],
-thanks [@cenk1cenk2]). You can now override popup global options on the fly using the newly added arguments of
-`@popup-toggle`.
+We've implemented several improvements to make it easier for other programs to
+integrate with this plugin ([#5], [#9], thanks [@cenk1cenk2]). You can now
+override popup global options on the fly using the newly added arguments of `@popup-toggle`.
 
 ### Added
 
@@ -67,14 +67,16 @@ thanks [@cenk1cenk2]). You can now override popup global options on the fly usin
 
 ### Changed
 
-- (**breaking**) Use xargs(1) and printf(1) to parse tmux commands ([#8]). This allows you to input `;` directly as the
-  command delimiter without worrying about Bash's interpretation. The new parser may yield results that differ from the
-  previous version, although this is usually not the case.
+- (**breaking**) Use xargs(1) and printf(1) to parse tmux commands ([#8]). This
+  allows you to input `;` directly as the command delimiter without worrying
+  about Bash's interpretation. The new parser may yield results that differ from
+  the previous version, although this is usually not the case.
 
 ### Fixed
 
 - Always retrieve option values from global ([61789c7]).
-- Address the breaking changes in `display-popup` introduced in tmux versions 3.5 and 3.5a ([#14]).
+- Address the breaking changes in `display-popup` introduced in tmux versions
+  3.5 and 3.5a ([#14]).
 
 [#5]: https://github.com/loichyan/tmux-toggle-popup/pull/8
 [#8]: https://github.com/loichyan/tmux-toggle-popup/pull/8
@@ -95,14 +97,16 @@ thanks [@cenk1cenk2]). You can now override popup global options on the fly usin
 
 ### Changed
 
-- (**breaking**) Use bash(1) to parse tmux commands, thus semicolons in hooks (`@popup-on-open` and `@popup-on-close`)
-  must now be explicitly escaped or quoted ([#1]).
+- (**breaking**) Use bash(1) to parse tmux commands, thus semicolons in hooks
+  (`@popup-on-open` and `@popup-on-close`) must now be explicitly escaped or
+  quoted ([#1]).
 - (**breaking**) Rename `@popup-on-open` to `@popup-on-init` ([#2]).
 
 ### Removed
 
-- (**breaking**) Remove `@popup-on-close`, as it cannot handle popup exits. Instead, consider setting the
-  `client-detached` and `pane-exited` tmux hooks in `@popup-on-init` ([#2]).
+- (**breaking**) Remove `@popup-on-close`, as it cannot handle popup exits.
+  Instead, consider setting the `client-detached` and `pane-exited` tmux hooks
+  in `@popup-on-init` ([#2]).
 
 ### Fixed
 
@@ -117,7 +121,8 @@ thanks [@cenk1cenk2]). You can now override popup global options on the fly usin
 
 ## [0.1.0] - 2024-05-28
 
-🎉 Initial release. See [README](https://github.com/loichyan/tmux-toggle-popup/blob/v0.1.0/README.md) for more details.
+🎉 Initial release. See [README](https://github.com/loichyan/tmux-toggle-popup/blob/v0.1.0/README.md)
+for more details.
 
 [Unreleased]: https://github.com/loichyan/tmux-toggle-popup/compare/v0.4.0..HEAD
 [0.4.0]: https://github.com/loichyan/tmux-toggle-popup/compare/v0.3.0..v0.4.0

--- a/README.md
+++ b/README.md
@@ -74,12 +74,11 @@ identify popup servers. You can check this variable and load different configura
 **Example**:
 
 ```tmux
-# configurations for popup servers
+# Configurations specified for popup servers
 if '[ -n "$TMUX_POPUP_SERVER" ]' {
     set -g exit-empty off
     set -g status off
 }
-# ...other configurations
 ```
 
 ### `@popup-id-format`
@@ -126,7 +125,7 @@ set -g @popup-on-init '
 set -g @popup-on-init '
   bind -n M-1 display random\ text \\; display and\ more
 '
-# or quoted
+# or quoted.
 set -g @popup-on-init "
   bind -n M-2 \"display 'random text' ; display 'and more'\"
 "

--- a/README.md
+++ b/README.md
@@ -106,10 +106,10 @@ with the popup name during the expansion.
 
 A hook consists of tmux commands. To write hooks, we support a limited version of `.tmux.conf`.
 
-To elaborate further, each tmux command can be delimited by semicolons (`;`) or line breaks. You can use escaped spaces
-(`\ `) or quotes (either `'` or `"`) to prevent an individual argument from being split. Additionally, you can nest
-different types of quotes within one another. Any character preceded by a backslash (`\`) is treated as a literal
-escape, meaning that `\;` is interpreted as `;`. To input `\;`, you need to escape the backslash, using `\\;`.
+To elaborate further, each tmux command must be delimited by semicolons (`;`). You can use escaped spaces (`\ `) or
+quotes (either `'` or `"`) to prevent an individual argument from being split. Additionally, you can nest different
+types of quotes within one another. Any character preceded by a backslash (`\`) is treated as a literal escape, meaning
+that `\;` is interpreted as `;`. To input `\;`, you need to escape the backslash, using `\\;`.
 
 A hook will be executed either in the caller session (i.e., the session that calls `@popup-toggle`) or in the popup
 session (i.e., the session where a popup resides).
@@ -117,9 +117,9 @@ session (i.e., the session where a popup resides).
 **Example**:
 
 ```tmux
+# Keep the server running and hide status bar.
 set -g @popup-on-init '
-  set exit-empty off
-  set status off
+  set exit-empty off ; set status off
 '
 # Bind to multiple commands should be escaped,
 set -g @popup-on-init '

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ A handy plugin that helps create toggleable popups.
 - Keystrokes: [Show Me the Key](https://showmethekey.alynx.one)
 - Rickroll: [rickrollrc](https://github.com/keroserene/rickrollrc)
 
-_Check [the dotfiles](https://github.com/loichyan/dotfiles/tree/5899f0e7572de4102261051277b22990e53f8bed) for more
-details_
+_Check [the dotfiles](https://github.com/loichyan/dotfiles/tree/5899f0e7572de4102261051277b22990e53f8bed)
+for more details_
 
 </details>
 
@@ -47,7 +47,8 @@ Add this line to the bottom of `.tmux.conf`:
 run ~/clone/path/toggle-popup.tmux
 ```
 
-Reload tmux environment with: `tmux source-file ~/.tmux.conf`. You should now be able to use the plugin.
+Reload tmux environment with: `tmux source-file ~/.tmux.conf`. You should now
+be able to use the plugin.
 
 ## ✍️ Usage
 
@@ -64,12 +65,14 @@ bind -n M-g run "#{@popup-toggle} -Ed'#{pane_current_path}' -w90% -h90% --name=l
 
 **Default**: `popup`
 
-**Description**: The socket name (`tmux -L {@popup-socket-name} ...`) of the server in which all popup sessions are
-opened. Typically, it’s recommended to open popups in a standalone server, as it may start many sessions for popups,
+**Description**: The socket name (`tmux -L {@popup-socket-name} ...`) of the
+server in which all popup sessions are opened. Typically, it’s recommended to
+open popups in a standalone server, as it may start many sessions for popups,
 which can be quite annoying when you open the session selector.
 
-A special environment variable, `$TMUX_POPUP_SERVER`, is set to its value before the server starts, which is used to
-identify popup servers. You can check this variable and load different configurations in your `.tmux.conf`.
+A special environment variable, `$TMUX_POPUP_SERVER`, is set to its value before
+the server starts, which is used to identify popup servers. You can check this
+variable and load different configurations in your `.tmux.conf`.
 
 **Example**:
 
@@ -85,16 +88,18 @@ if '[ -n "$TMUX_POPUP_SERVER" ]' {
 
 **Default**: `#{b:socket_path}/#{session_name}/#{b:pane_current_path}/{popup_name}`
 
-**Description**: A format string used to generate IDs for each popup, allowing you to customize how popups are shared
-across sessions, windows, and panes. By default, popups are independent across sessions, and in each session, popups are
-shared among the same project (identified by the directory name). A placedholder named `{popup_name}` is substituted
-with the popup name during the expansion.
+**Description**: A format string used to generate IDs for each popup, allowing
+you to customize how popups are shared across sessions, windows, and panes. By
+default, popups are independent across sessions, and in each session, popups are
+shared among the same project (identified by the directory name). A placedholder
+named `{popup_name}` is substituted with the popup name during the expansion.
 
 ### `@popup-autostart`
 
 **Default**: `off`
 
-**Description**: If enabled, the designated tmux server for popups will start automatically.
+**Description**: If enabled, the designated tmux server for popups will start
+automatically.
 
 ### `@popup-toggle-mode`
 
@@ -104,15 +109,19 @@ with the popup name during the expansion.
 
 ## 🪝 Hooks
 
-A hook consists of tmux commands. To write hooks, we support a limited version of `.tmux.conf`.
+A hook consists of tmux commands. To write hooks, we support a limited version
+of `.tmux.conf`.
 
-To elaborate further, each tmux command must be delimited by semicolons (`;`). You can use escaped spaces (`\ `) or
-quotes (either `'` or `"`) to prevent an individual argument from being split. Additionally, you can nest different
-types of quotes within one another. Any character preceded by a backslash (`\`) is treated as a literal escape, meaning
-that `\;` is interpreted as `;`. To input `\;`, you need to escape the backslash, using `\\;`.
+To elaborate further, each tmux command must be delimited by semicolons (`;`).
+You can use escaped spaces (`\ `) or quotes (either `'` or `"`) to prevent an
+individual argument from being split. Additionally, you can nest different types
+of quotes within one another. Any character preceded by a backslash (`\`) is
+treated as a literal escape, meaning that `\;` is interpreted as `;`. To input
+`\;`, you need to escape the backslash, using `\\;`.
 
-A hook will be executed either in the caller session (i.e., the session that calls `@popup-toggle`) or in the popup
-session (i.e., the session where a popup resides).
+A hook will be executed either in the caller session (i.e., the session that
+calls `@popup-toggle`) or in the popup session (i.e., the session where a popup
+resides).
 
 **Example**:
 
@@ -135,41 +144,50 @@ set -g @popup-on-init "
 
 **Default**: `set exit-empty off ; set status off`
 
-**Description**: tmux commands executed in the popup each time after it is opened.
+**Description**: tmux commands executed in the popup each time after it is
+opened.
 
 ### `@popup-before-open`
 
 **Default**: empty
 
-**Description**: tmux commands executed in the caller each time before a popup is opened.
+**Description**: tmux commands executed in the caller each time before a popup
+is opened.
 
 ### `@popup-after-close`
 
 **Default**: empty
 
-**Description**: tmux commands executed in the caller each time after a popup is closed.
+**Description**: tmux commands executed in the caller each time after a popup
+is closed.
 
 ## ⌨️ Keybindings
 
 ### `@popup-toggle`
 
-**Description**: A shell script to toggle a popup. When invoked in your working session, it opens a reusable popup
-window identified by `--name`. It supports three modes to handle nested toggle calls, specifically when invoked in an
+**Description**: A shell script to toggle a popup. When invoked in your working
+session, it opens a reusable popup window identified by `--name`. It supports
+three modes to handle nested toggle calls, specifically when invoked in an
 opened popup with a different name specified:
 
-1. `switch`: The default mode. Keep the popup window open and switch to the new popup.
-2. `force-close`: Close the opened popup window. This is the expected behavior when the name matches or no arguments are
-   provided.
-3. `force-open`: Open a new popup window within the current one, i.e., popup-in-popup.
+1. `switch`: The default mode. Keep the popup window open and switch to the new
+   popup.
+2. `force-close`: Close the opened popup window. This is the expected behavior
+   when the name matches or no arguments are provided.
+3. `force-open`: Open a new popup window within the current one, i.e.,
+   popup-in-popup.
 
-If you have set popup keybindings in your `.tmux.conf`, which should be loaded in both your default server and the popup
-server, there's no need to worry about the toggle keys. For instance, if `M-t` is bound to open a shell, you can press
-it to open a popup in your working session and then press it again to close the popup.
+If you have set popup keybindings in your `.tmux.conf`, which should be loaded
+in both your default server and the popup server, there's no need to worry about
+the toggle keys. For instance, if `M-t` is bound to open a shell, you can press
+it to open a popup in your working session and then press it again to close the
+popup.
 
-However, if you wish to set a keybinding outside of `.tmux.conf`, it can get a bit tricky. You may refer to
-[#5](https://github.com/loichyan/tmux-toggle-popup/pull/5) for more details. TL;DR, you can pass your desired key(s) to
-`@popup-toggle` using `--toggle-key M-t`, and the script will handle the necessary adjustments. You can also specify a
-different key table using `--toggle '-n M-t'` or `--toggle '-Troot M-t'`.
+However, if you wish to set a keybinding outside of `.tmux.conf`, it can get a
+bit tricky. You may refer to [#5](https://github.com/loichyan/tmux-toggle-popup/pull/5)
+for more details. TL;DR, you can pass your desired key(s) to `@popup-toggle`
+using `--toggle-key M-t`, and the script will handle the necessary adjustments.
+You can also specify a different key table using `--toggle '-n M-t'` or `--toggle '-Troot M-t'`.
 
 ```text
 Usage:
@@ -207,9 +225,10 @@ bind -n M-t run "#{@popup-toggle} -Ed'#{pane_current_path}' -w75% -h75%"
 
 ### `@popup-focus`
 
-**Description**: Manually send focus enter or leave events. The name of the program that accepts focus events can be
-specified and events are sent only if the current program matches any of the names; if no name is provided, focus events
-are always sent.
+**Description**: Manually send focus enter or leave events. The name of the
+program that accepts focus events can be specified and events are sent only if
+the current program matches any of the names; if no name is provided, focus
+events are always sent.
 
 ```text
 Usage:
@@ -228,8 +247,8 @@ Examples:
 
 **Example**:
 
-A workaround for [tmux/tmux#3991](https://github.com/tmux/tmux/issues/3991), which has been fixed in
-[tmux/tmux@a869693405f9](https://github.com/tmux/tmux/commit/a869693405f99c8ca8e2da32a08534489ce165f2).
+A workaround for [tmux/tmux#3991](https://github.com/tmux/tmux/issues/3991),
+which has been fixed in [tmux/tmux@a869693405f9](https://github.com/tmux/tmux/commit/a869693405f99c8ca8e2da32a08534489ce165f2).
 
 ```tmux
 set -g @popup-before-open 'run "#{@popup-focus} --leave nvim"'

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -37,9 +37,9 @@ showvariable() {
 # Parses the tmux script into sequences and escapes each one, ensuring they can
 # be safely interpreted by Bash.
 makecmds() {
-	# Force to use bash's bulitin printf as macOS's printf does not support "%q".
-	# The first argument to `bash -c` is the script name, so we need a dummy
-	# name to prevent it from being "eaten" by Bash.
+	# Force to use bash's bulitin printf as macOS's printf does not support
+	# "%q". The first argument to `bash -c` is the script name, so we need a
+	# dummy name to prevent it from being "eaten" by Bash.
 	echo "$*" | xargs bash -c 'printf "%q " "$@"' _
 }
 

--- a/scripts/really_open.sh
+++ b/scripts/really_open.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 
-# clear the temporary variable
+# Clear the temporary variable
 open_script="${__tmux_popup_open:-}"
 unset -v __tmux_popup_open
 if [ -n "$open_script" ]; then
-	# execute the open script if exists
+	# Execute the open script if exists,
 	eval "$open_script"
 else
-	# or fallback to user's default shell
+	# or fallback to user's default shell.
 	exec "$SHELL" "$@"
 fi

--- a/scripts/toggle.sh
+++ b/scripts/toggle.sh
@@ -47,7 +47,7 @@ declare name toggle_mode open_cmds on_cleanup popup_id
 prepare_open() {
 	local on_init="${on_init:-$(showopt @popup-on-init "$DEFAULT_ON_INIT")}"
 
-	# create temporary toggle keys in the opened popup
+	# Create temporary toggle keys in the opened popup
 	for k in "${toggle_keys[@]}"; do
 		on_init+=" ; bind $k run \"#{@popup-toggle} --name='$name' --toggle-mode='$toggle_mode'\""
 		on_cleanup+=" ; unbind $k"
@@ -69,16 +69,16 @@ main() {
 		case "$OPT" in
 		[BCE]) popup_args+=("-$OPT") ;;
 		[bcdhsStTwxy]) popup_args+=("-$OPT" "$OPTARG") ;;
-		# forward environment overrides to popup sessions
+		# Forward environment overrides to popup sessions
 		e) open_args+=("-e" "$OPTARG") ;;
 		name | toggle-key | socket-name | id-format | \
 			toggle-mode | on-init | before-open | after-close)
 			OPTARG="${OPTARG:${#OPT}}"
 			if [[ ${OPTARG::1} == '=' ]]; then
-				# format: `--name=value`
+				# FORMAT: `--name=value`
 				OPTARG="${OPTARG:1}"
 			else
-				# format: `--name value`
+				# FORMAT: `--name value`
 				OPTARG="${!OPTIND}"
 				OPTIND=$((OPTIND + 1))
 			fi
@@ -104,48 +104,48 @@ main() {
 		if [[ $name == "$opened_name" || $OPTIND -eq 1 || $toggle_mode == "force-close" ]]; then
 			exec tmux detach >/dev/null
 		elif [[ $toggle_mode == "switch" ]]; then
-			# reuse the caller's ID format to ensure we open the intended popup
+			# Reuse the caller's ID format to ensure we open the intended popup
 			id_format="$(showvariable @__popup_id_format)"
-			open_args+=("-d") # create the target session if not exists
+			open_args+=("-d") # Create the target session if not exists
 			prepare_open
-			eval tmux -C "$open_cmds" &>/dev/null || true # ignore error if already created
+			eval tmux -C "$open_cmds" &>/dev/null || true # Ignore error if already created
 			exec tmux switch -t "$popup_id" >/dev/null
 		elif [[ $toggle_mode != "force-open" ]]; then
 			die "illegal toggle mode: $toggle_mode"
 		fi
 	fi
 
-	# hook: before-open
+	# HOOK: before-open
 	before_open="${before_open:-$(showopt @popup-before-open)}"
 	if [[ -n $before_open ]]; then
 		eval "tmux -C $(makecmds "$before_open")" >/dev/null
 	fi
 
-	# expand the configured ID format
+	# Expand the configured ID format
 	id_format="$(format "${id_format:-$(showopt @popup-id-format "$DEFAULT_ID_FORMAT")}")"
-	open_args+=("-A") # create the target session and attach to it
+	open_args+=("-A") # Create the target session and attach to it
 	prepare_open
 	socket_name="${socket_name:-$(get_socket_name)}"
 	open_script="exec tmux -L '$socket_name' $open_cmds >/dev/null"
 
 	# Starting from version 3.5, tmux uses the user's `default-shell` to execute
-	# shell commands. However, our scripts are written in `sh`, which may not be
-	# recognized by some shells that are incompatible with it. To address this,
-	# we put the entire script in a temporary env variable and call `./really_open.sh`
-	# to run these commands. This approach only requires the user's default
-	# shell to support the `exec` command, which we believe most shells do.
+	# Shell commands. However, our scripts are written in `sh`, which may not be
+	# Recognized by some shells that are incompatible with it. To address this,
+	# We put the entire script in a temporary env variable and call `./really_open.sh`
+	# To run these commands. This approach only requires the user's default
+	# Shell to support the `exec` command, which we believe most shells do.
 	tmux popup "${popup_args[@]}" \
 		-e TMUX_POPUP_SERVER="$socket_name" \
 		-e __tmux_popup_open="$open_script" \
 		"exec $SRC_DIR/really_open.sh"
 
-	# undo temporary changes
+	# Undo temporary changes
 	if [[ -n ${on_cleanup-} ]]; then
-		# ignore error if the server has already stopped
+		# Ignore error if the server has already stopped
 		eval "tmux -NCL '$socket_name' $(makecmds "$on_cleanup")" &>/dev/null || true
 	fi
 
-	# hook: after-close
+	# HOOK: after-close
 	after_close="${after_close:-$(showopt @popup-after-close)}"
 	if [[ -n $after_close ]]; then
 		eval "tmux -C $(makecmds "$after_close")" >/dev/null

--- a/toggle-popup.tmux
+++ b/toggle-popup.tmux
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-# name:     tmux-toggle-popup
-# version:  0.4.0
-# authors:  Loi Chyan <loichyan@foxmail.com>
-# license:  MIT OR Apache-2.0
+# Name:     tmux-toggle-popup
+# Version:  0.4.0
+# Authors:  Loi Chyan <loichyan@foxmail.com>
+# License:  MIT OR Apache-2.0
 
 SRC_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
@@ -19,11 +19,11 @@ set_keybindings() {
 }
 
 handle_autostart() {
-	# do not start itself within a popup server
+	# Do not start itself within a popup server
 	if [[ $(showopt @popup-autostart) == "on" && -z ${TMUX_POPUP_SERVER-} ]]; then
-		# set $TMUX_POPUP_SERVER, used to identify the popup server
+		# Set $TMUX_POPUP_SERVER, used to identify the popup server
 		socket_name="$(get_socket_name)"
-		# propagate user's default shell
+		# Propagate user's default shell
 		default_shell="$(get_default_shell)"
 		TMUX_POPUP_SERVER="$socket_name" SHELL="$default_shell" \
 			tmux -L "$socket_name" set exit-empty off \; start &


### PR DESCRIPTION
Remove the obsolete syntax for hook options deprecated in #8, specifically the use of line breaks as command delimiters. Also, format some comments and documents.