### PR TITLE
feat: add argument `@popup-toggle --id <id>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,8 @@ are noticeable to end-users since the last release. For developers, this project
 
 ### Added
 
-- Add a new argument, `@popup-toggle --id <id>`, to set the ID of a popup directly ([#XX]).
+- Add a new argument, `@popup-toggle --id <id>`, to directly set the ID of a
+  popup, useful for creating globally shared popups ([#27]).
 
 ## [0.4.0] - 2024-11-23
 
@@ -55,7 +56,7 @@ are noticeable to end-users since the last release. For developers, this project
 
 [#21]: https://github.com/loichyan/tmux-toggle-popup/pull/21
 [#23]: https://github.com/loichyan/tmux-toggle-popup/pull/23
-[#XX]: https://github.com/loichyan/tmux-toggle-popup/pull/XX
+[#27]: https://github.com/loichyan/tmux-toggle-popup/pull/27
 
 ## [0.3.0] - 2024-10-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ are noticeable to end-users since the last release. For developers, this project
 
 ## [Unreleased]
 
+### Added
+
+- Add a new argument, `@popup-toggle --id <id>`, to set the ID of a popup directly ([#XX]).
+
 ## [0.4.0] - 2024-11-23
 
 ### Added
@@ -51,6 +55,7 @@ are noticeable to end-users since the last release. For developers, this project
 
 [#21]: https://github.com/loichyan/tmux-toggle-popup/pull/21
 [#23]: https://github.com/loichyan/tmux-toggle-popup/pull/23
+[#XX]: https://github.com/loichyan/tmux-toggle-popup/pull/XX
 
 ## [0.3.0] - 2024-10-21
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Usage:
 Options:
 
   --name <name>               Popup name [Default: "default"]
+  --id <id>                   Popup ID, default to the expanded ID format
   --toggle-mode <mode>        Action to handle nested calls [Default: "switch"]
   --toggle-key <key>          Bind additional keys to close the opened popup
   -[BCE]                      Flags passed to display-popup

--- a/scripts/toggle.sh
+++ b/scripts/toggle.sh
@@ -17,6 +17,7 @@ usage() {
 		Options:
 
 		  --name <name>               Popup name [Default: "$DEFAULT_NAME"]
+		  --id <id>                   Popup ID, default to the expanded ID format
 		  --toggle-mode <mode>        Action to handle nested calls [Default: "$DEFAULT_TOGGLE_MODE"]
 		  --toggle-key <key>          Bind additional keys to close the opened popup
 		  -[BCE]                      Flags passed to display-popup
@@ -53,7 +54,7 @@ prepare_open() {
 		on_cleanup+=" ; unbind $k"
 	done
 
-	popup_id="$(interpolate popup_name "$name" "$id_format")"
+	popup_id="${id:-$(interpolate popup_name "$name" "$id_format")}"
 	open_cmds+="$(
 		escape \
 			new "${open_args[@]}" -s "$popup_id" "${program[@]}" \; \
@@ -71,7 +72,7 @@ main() {
 		[bcdhsStTwxy]) popup_args+=("-$OPT" "$OPTARG") ;;
 		# Forward environment overrides to popup sessions
 		e) open_args+=("-e" "$OPTARG") ;;
-		name | toggle-key | socket-name | id-format | \
+		name | toggle-key | socket-name | id-format | id | \
 			toggle-mode | on-init | before-open | after-close)
 			OPTARG="${OPTARG:${#OPT}}"
 			if [[ ${OPTARG::1} == '=' ]]; then

--- a/toggle-popup.tmux
+++ b/toggle-popup.tmux
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Name:     tmux-toggle-popup
-# Version:  0.4.0
+# Version:  0.4.1-dev
 # Authors:  Loi Chyan <loichyan@foxmail.com>
 # License:  MIT OR Apache-2.0
 


### PR DESCRIPTION
Add a new argument, `@popup-toggle --id <id>`, useful for creating a globally shared popup. This can also be done by using `@popup-toggle --id-format <id>`, but it breaks the consistency of `id-format` across different popups, which is crucial for the `switch` toggle mode function.