### PR TITLE
fix: replace special chars in popup ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,13 @@ are noticeable to end-users since the last release. For developers, this project
 - Add a new argument, `@popup-toggle --id <id>`, to directly set the ID of a
   popup, useful for creating globally shared popups ([#27])
 
+### Fixed
+
+- Replace special characters in the popup ID to ensure `@popup-toggle` does not
+  fail if the current directory contains dots (`.`) or colons (`:`) ([#29])
+
 [#27]: https://github.com/loichyan/tmux-toggle-popup/pull/27
+[#29]: https://github.com/loichyan/tmux-toggle-popup/pull/29
 
 ## [0.4.0] - 2024-11-23
 

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -64,5 +64,5 @@ interpolate() {
 # Replace special chars with '_' in a session name.
 # See: https://github.com/tmux/tmux/blob/ef68debc8d9e0e5567d328766f705bb1f42b7c51/session.c#L242
 check_popup_id() {
-	sed 's/[.:]/_/g'
+	echo "${1//[.:]/_}"
 }

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -60,3 +60,9 @@ interpolate() {
 	done
 	echo "$result"
 }
+
+# Replace special chars with '_' in a session name.
+# See: https://github.com/tmux/tmux/blob/ef68debc8d9e0e5567d328766f705bb1f42b7c51/session.c#L242
+check_popup_id() {
+	sed 's/[.:]/_/g'
+}

--- a/scripts/toggle.sh
+++ b/scripts/toggle.sh
@@ -54,7 +54,8 @@ prepare_open() {
 		on_cleanup+=" ; unbind $k"
 	done
 
-	popup_id="${id:-$(interpolate popup_name "$name" "$id_format" | check_popup_id)}"
+	popup_id="${id:-$(interpolate popup_name "$name" "$id_format")}"
+	popup_id="$(check_popup_id "$popup_id")"
 	open_cmds+="$(
 		escape \
 			new "${open_args[@]}" -s "$popup_id" "${program[@]}" \; \

--- a/scripts/toggle.sh
+++ b/scripts/toggle.sh
@@ -54,7 +54,7 @@ prepare_open() {
 		on_cleanup+=" ; unbind $k"
 	done
 
-	popup_id="${id:-$(interpolate popup_name "$name" "$id_format")}"
+	popup_id="${id:-$(interpolate popup_name "$name" "$id_format" | check_popup_id)}"
 	open_cmds+="$(
 		escape \
 			new "${open_args[@]}" -s "$popup_id" "${program[@]}" \; \


### PR DESCRIPTION
Replace special characters in the popup ID to ensure `@popup-toggle` does not fail if the current directory contains special chars: tmux replaces special chars like `.` or `:` in a session name, it's necessary to perform the same behavior so as to get a proper name.