### PR TITLE
fix: forward working directory to popup sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,9 +41,12 @@ are noticeable to end-users since the last release. For developers, this project
 
 - Replace special characters in the popup ID to ensure `@popup-toggle` does not
   fail if the current directory contains dots (`.`) or colons (`:`) ([#29])
+- Forward working directory to popup sessions to ensure `@popup-toggle -d <dir>`
+  functions properly in switch mode (#30)
 
 [#27]: https://github.com/loichyan/tmux-toggle-popup/pull/27
 [#29]: https://github.com/loichyan/tmux-toggle-popup/pull/29
+[#30]: https://github.com/loichyan/tmux-toggle-popup/pull/30
 
 ## [0.4.0] - 2024-11-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ are noticeable to end-users since the last release. For developers, this project
 - Replace special characters in the popup ID to ensure `@popup-toggle` does not
   fail if the current directory contains dots (`.`) or colons (`:`) ([#29])
 - Forward working directory to popup sessions to ensure `@popup-toggle -d <dir>`
-  functions properly in switch mode (#30)
+  functions properly in switch mode ([#30])
 
 [#27]: https://github.com/loichyan/tmux-toggle-popup/pull/27
 [#29]: https://github.com/loichyan/tmux-toggle-popup/pull/29

--- a/scripts/toggle.sh
+++ b/scripts/toggle.sh
@@ -71,6 +71,8 @@ main() {
 		case "$OPT" in
 		[BCE]) popup_args+=("-$OPT") ;;
 		[bcdhsStTwxy]) popup_args+=("-$OPT" "$OPTARG") ;;
+		# Forward working directory to popup sessions
+		d) open_args+=("-c" "$OPTARG") ;;
 		# Forward environment overrides to popup sessions
 		e) open_args+=("-e" "$OPTARG") ;;
 		name | toggle-key | socket-name | id-format | id | \

--- a/scripts/toggle.sh
+++ b/scripts/toggle.sh
@@ -70,7 +70,7 @@ main() {
 		if [[ $OPT == '-' ]]; then OPT="${OPTARG%%=*}"; fi
 		case "$OPT" in
 		[BCE]) popup_args+=("-$OPT") ;;
-		[bcdhsStTwxy]) popup_args+=("-$OPT" "$OPTARG") ;;
+		[bchsStTwxy]) popup_args+=("-$OPT" "$OPTARG") ;;
 		# Forward working directory to popup sessions
 		d) open_args+=("-c" "$OPTARG") ;;
 		# Forward environment overrides to popup sessions


### PR DESCRIPTION
Forward working directory to popup sessions to ensure `@popup-toggle -d <dir>` functions properly in switch mode.