### PR TITLE
fix: forward current ID format in switch mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,11 +42,13 @@ are noticeable to end-users since the last release. For developers, this project
 - Replace special characters in the popup ID to ensure `@popup-toggle` does not
   fail if the current directory contains dots (`.`) or colons (`:`) ([#29])
 - Forward working directory to popup sessions to ensure `@popup-toggle -d <dir>`
-  functions properly in switch mode ([#30])
+- Forward current popup's ID format in switch mode to ensure the intended popup
+  is opened when switching ([#31])
 
 [#27]: https://github.com/loichyan/tmux-toggle-popup/pull/27
 [#29]: https://github.com/loichyan/tmux-toggle-popup/pull/29
 [#30]: https://github.com/loichyan/tmux-toggle-popup/pull/30
+[#31]: https://github.com/loichyan/tmux-toggle-popup/pull/31
 
 ## [0.4.0] - 2024-11-23
 

--- a/scripts/toggle.sh
+++ b/scripts/toggle.sh
@@ -56,12 +56,9 @@ prepare_open() {
 
 	popup_id="${id:-$(interpolate popup_name "$name" "$id_format")}"
 	popup_id="$(check_popup_id "$popup_id")"
-	open_cmds+="$(
-		escape \
-			new "${open_args[@]}" -s "$popup_id" "${program[@]}" \; \
-			set @__popup_opened "$name" \; \
-			set @__popup_id_format "$id_format" \;
-	)"
+	open_cmds+="$(escape new "${open_args[@]}" -s "$popup_id" "${program[@]}" \;)"
+	open_cmds+="$(escape set @__popup_opened "$name" \;)"
+	open_cmds+="$(escape set @__popup_id_format "$id_format" \;)"
 	open_cmds+="$(makecmds "$on_init")"
 }
 
@@ -113,7 +110,8 @@ main() {
 			open_args+=("-d") # Create the target session if not exists
 			prepare_open
 			eval tmux -C "$open_cmds" &>/dev/null || true # Ignore error if already created
-			exec tmux switch -t "$popup_id" >/dev/null
+			# Forward current ID format so that this popup can be switched back.
+			exec tmux switch -t "$popup_id" \; set @__popup_id_format "$id_format" \; >/dev/null
 		elif [[ $toggle_mode != "force-open" ]]; then
 			die "illegal toggle mode: $toggle_mode"
 		fi


### PR DESCRIPTION
Forward current popup's ID format in switch mode to ensure the intended popup is opened when switching.