### PR TITLE
perf: reduce the lantency of popup toggles

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CURRENT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 status=0
 for test in "$CURRENT_DIR"/tests/*; do

--- a/src/focus.sh
+++ b/src/focus.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CURRENT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # shellcheck source=./helpers.sh
 source "$CURRENT_DIR/helpers.sh"
@@ -40,7 +40,7 @@ check_program() {
 
 main() {
 	while getopts :-: OPT; do
-		if [[ $OPT == '-' ]]; then OPT="${OPTARG%%=*}"; fi
+		if [[ $OPT == '-' ]]; then OPT=${OPTARG%%=*}; fi
 		case "$OPT" in
 		enter) mode=I ;;
 		leave) mode=O ;;

--- a/src/focus.sh
+++ b/src/focus.sh
@@ -48,7 +48,7 @@ main() {
 			usage
 			exit
 			;;
-		*) badopt ;;
+		*) die_badopt ;;
 		esac
 	done
 	programs=("${@:$OPTIND}")

--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -65,6 +65,6 @@ interpolate() {
 
 # Replace special chars with '_' in a session name.
 # See: https://github.com/tmux/tmux/blob/ef68debc8d9e0e5567d328766f705bb1f42b7c51/session.c#L242
-check_popup_id() {
+escape_session_name() {
 	echo "${1//[.:]/_}"
 }

--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -54,11 +54,13 @@ format() {
 # the expansion. All `{variable}` placeholders in the format string will be
 # replaced with their corresponding values.
 interpolate() {
-	local result
+	local result key val
 	result=${*: -1}
 	while [[ $# -gt 1 ]]; do
-		result=${result//"{$1}"/$2}
-		shift 2
+		key=${1%%=*}
+		val=${1:${#key}+1}
+		result=${result//"{$key}"/$val}
+		shift
 	done
 	echo "$result"
 }

--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -25,7 +25,8 @@ badopt() {
 # Returns the value of the specified option or the second argument as the
 # fallback value if the option is empty.
 showopt() {
-	v="$(tmux show -gqv "$1")"
+	local v
+	v=$(tmux show -gqv "$1")
 	echo "${v:-"${2-}"}"
 }
 
@@ -53,9 +54,10 @@ format() {
 # the expansion. All `{variable}` placeholders in the format string will be
 # replaced with their corresponding values.
 interpolate() {
-	local result="${*: -1}"
+	local result
+	result=${*: -1}
 	while [[ $# -gt 1 ]]; do
-		result="${result//"{$1}"/$2}"
+		result=${result//"{$1}"/$2}
 		shift 2
 	done
 	echo "$result"

--- a/src/toggle.sh
+++ b/src/toggle.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CURRENT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # shellcheck source=./helpers.sh
 source "$CURRENT_DIR/helpers.sh"
@@ -46,7 +46,7 @@ usage() {
 # - `popup_id` is set to the expanded popup session name
 declare name toggle_mode open_cmds on_cleanup popup_id
 prepare_open() {
-	local on_init="${on_init:-$(showopt @popup-on-init "$DEFAULT_ON_INIT")}"
+	local on_init=${on_init:-$(showopt @popup-on-init "$DEFAULT_ON_INIT")}
 
 	# Create temporary toggle keys in the opened popup
 	for k in "${toggle_keys[@]}"; do
@@ -54,17 +54,17 @@ prepare_open() {
 		on_cleanup+=" ; unbind $k"
 	done
 
-	popup_id="${id:-$(interpolate popup_name "$name" "$id_format")}"
-	popup_id="$(check_popup_id "$popup_id")"
-	open_cmds+="$(escape new "${open_args[@]}" -s "$popup_id" "${program[@]}" \;)"
-	open_cmds+="$(escape set @__popup_opened "$name" \;)"
-	open_cmds+="$(escape set @__popup_id_format "$id_format" \;)"
-	open_cmds+="$(makecmds "$on_init")"
+	popup_id=${id:-$(interpolate popup_name "$name" "$id_format")}
+	popup_id=$(check_popup_id "$popup_id")
+	open_cmds+=$(escape new "${open_args[@]}" -s "$popup_id" "${program[@]}" \;)
+	open_cmds+=$(escape set @__popup_opened "$name" \;)
+	open_cmds+=$(escape set @__popup_id_format "$id_format" \;)
+	open_cmds+=$(makecmds "$on_init")
 }
 
 main() {
 	while getopts :-:BCEb:c:d:e:h:s:S:t:T:w:x:y: OPT; do
-		if [[ $OPT == '-' ]]; then OPT="${OPTARG%%=*}"; fi
+		if [[ $OPT == '-' ]]; then OPT=${OPTARG%%=*}; fi
 		case "$OPT" in
 		[BCE]) popup_args+=("-$OPT") ;;
 		[bchsStTwxy]) popup_args+=("-$OPT" "$OPTARG") ;;
@@ -74,13 +74,13 @@ main() {
 		e) open_args+=("-e" "$OPTARG") ;;
 		name | toggle-key | socket-name | id-format | id | \
 			toggle-mode | on-init | before-open | after-close)
-			OPTARG="${OPTARG:${#OPT}}"
+			OPTARG=${OPTARG:${#OPT}}
 			if [[ ${OPTARG::1} == '=' ]]; then
 				# FORMAT: `--name=value`
-				OPTARG="${OPTARG:1}"
+				OPTARG=${OPTARG:1}
 			else
 				# FORMAT: `--name value`
-				OPTARG="${!OPTIND}"
+				OPTARG=${!OPTIND}
 				OPTIND=$((OPTIND + 1))
 			fi
 			if [[ $OPT == "toggle-key" ]]; then
@@ -97,16 +97,16 @@ main() {
 		esac
 	done
 	program=("${@:$OPTIND}")
-	name="${name:-$DEFAULT_NAME}"
-	toggle_mode="${toggle_mode:-$(showopt @popup-toggle-mode "$DEFAULT_TOGGLE_MODE")}"
+	name=${name:-$DEFAULT_NAME}
+	toggle_mode=${toggle_mode:-$(showopt @popup-toggle-mode "$DEFAULT_TOGGLE_MODE")}
 
-	opened_name="$(showvariable @__popup_opened)"
+	opened_name=$(showvariable @__popup_opened)
 	if [[ -n $opened_name ]]; then
 		if [[ $name == "$opened_name" || $OPTIND -eq 1 || $toggle_mode == "force-close" ]]; then
 			exec tmux detach >/dev/null
 		elif [[ $toggle_mode == "switch" ]]; then
 			# Reuse the caller's ID format to ensure we open the intended popup
-			id_format="$(showvariable @__popup_id_format)"
+			id_format=$(showvariable @__popup_id_format)
 			open_args+=("-d") # Create the target session if not exists
 			prepare_open
 			eval tmux -C "$open_cmds" &>/dev/null || true # Ignore error if already created
@@ -118,16 +118,16 @@ main() {
 	fi
 
 	# HOOK: before-open
-	before_open="${before_open:-$(showopt @popup-before-open)}"
+	before_open=${before_open:-$(showopt @popup-before-open)}
 	if [[ -n $before_open ]]; then
 		eval "tmux -C $(makecmds "$before_open")" >/dev/null
 	fi
 
 	# Expand the configured ID format
-	id_format="$(format "${id_format:-$(showopt @popup-id-format "$DEFAULT_ID_FORMAT")}")"
+	id_format=$(format "${id_format:-$(showopt @popup-id-format "$DEFAULT_ID_FORMAT")}")
 	open_args+=("-A") # Create the target session and attach to it
 	prepare_open
-	socket_name="${socket_name:-$(get_socket_name)}"
+	socket_name=${socket_name:-$(get_socket_name)}
 	open_script="exec tmux -L '$socket_name' $open_cmds >/dev/null"
 
 	# Starting from version 3.5, tmux uses the user's `default-shell` to execute
@@ -148,7 +148,7 @@ main() {
 	fi
 
 	# HOOK: after-close
-	after_close="${after_close:-$(showopt @popup-after-close)}"
+	after_close=${after_close:-$(showopt @popup-after-close)}
 	if [[ -n $after_close ]]; then
 		eval "tmux -C $(makecmds "$after_close")" >/dev/null
 	fi

--- a/src/toggle.sh
+++ b/src/toggle.sh
@@ -55,7 +55,7 @@ prepare_open() {
 	done
 
 	popup_id=${id:-$(interpolate popup_name "$name" "$id_format")}
-	popup_id=$(check_popup_id "$popup_id")
+	popup_id=$(escape_session_name "$popup_id")
 	open_cmds+=$(escape new "${open_args[@]}" -s "$popup_id" "${program[@]}" \;)
 	open_cmds+=$(escape set @__popup_opened "$name" \;)
 	open_cmds+=$(escape set @__popup_id_format "$id_format" \;)

--- a/src/variables.sh
+++ b/src/variables.sh
@@ -1,16 +1,8 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2034
 
-# shellcheck disable=2034
 DEFAULT_NAME='default'
 DEFAULT_SOCKET_NAME='popup'
 DEFAULT_ID_FORMAT='#{b:socket_path}/#{session_name}/#{b:pane_current_path}/{popup_name}'
 DEFAULT_TOGGLE_MODE='switch'
 DEFAULT_ON_INIT="set exit-empty off ; set status off"
-
-get_socket_name() {
-	showopt @popup-socket-name "$DEFAULT_SOCKET_NAME"
-}
-
-get_default_shell() {
-	showopt default-shell "$SHELL"
-}

--- a/tests/command_parser_tests.sh
+++ b/tests/command_parser_tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CURRENT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # shellcheck source=../src//helpers.sh
 source "$CURRENT_DIR/../src/helpers.sh"

--- a/tests/command_parser_tests.sh
+++ b/tests/command_parser_tests.sh
@@ -13,7 +13,7 @@ test_fail() {
 
 # Simulates Bash arguments interpretation.
 reparse_commands() {
-	# shellcheck disable=2046
+	# shellcheck disable=SC2046
 	eval printf '%s\\n' $(cat)
 }
 
@@ -24,7 +24,7 @@ test_parse_commands() {
 	local commands=()
 	while IFS= read -r command; do
 		commands+=("$command")
-	done < <(makecmds "$1" | reparse_commands)
+	done < <(parse_cmds "$1" | reparse_commands)
 	shift
 
 	if [[ $# -ne ${#commands[@]} ]]; then

--- a/tests/helper_tests.sh
+++ b/tests/helper_tests.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2154,SC2120
+
 set -euo pipefail
 
 CURRENT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
@@ -11,23 +13,46 @@ test_fail() {
 	exit 1
 }
 
-test_interpolate() {
-	local result
-	result=$(interpolate "${@}" "$format")
-
-	if [[ $result != "$expected" ]]; then
-		test_fail "$result != $expected"
+declare output expected
+assert_eq() {
+	local left right
+	left=${1:-"$output"}
+	right=${2:-"$expected"}
+	if [[ $left != "$right" ]]; then
+		test_fail "$left != $right"
 	fi
 }
 
+test_interpolate() {
+	output=$(interpolate "${@}" "$format")
+	assert_eq
+}
+
+echo "test: no_interpolate_of_unknown"
 format="{session}/{project}/{popup_name}"
 expected="working/{project}/default"
 test_interpolate session="working" popup_name="default"
 
+echo "test: interpolate_multi"
 format="{var1}/{var2}/{var2}/{var1}"
 expected="value1/value2/value2/value1"
 test_interpolate var1="value1" var2="value2"
 
+echo "test: interpolate_with_equals"
 format="{var1}/{var2}/{var2}/{var1}"
 expected="var1=value1/var2=value2/var2=value2/var1=value1"
 test_interpolate var1="var1=value1" var2="var2=value2"
+
+# Simulates a tmux response.
+tmux() {
+	echo "value1"
+	echo "value2"
+	echo "value3"
+}
+
+echo "test: batch_get_options"
+expected=$(printf "%s\n" format1 format2 format3)
+batch_get_options var1=format1 var2=format2 var3=format3
+assert_eq "$var1" "value1"
+assert_eq "$var2" "value2"
+assert_eq "$var3" "value3"

--- a/tests/helper_tests.sh
+++ b/tests/helper_tests.sh
@@ -12,21 +12,22 @@ test_fail() {
 }
 
 test_interpolate() {
-	format=$1" expected="$2
-	result=$(interpolate "${@:3}" "$format")
+	local result
+	result=$(interpolate "${@}" "$format")
 
 	if [[ $result != "$expected" ]]; then
 		test_fail "$result != $expected"
 	fi
 }
 
-test_interpolate \
-	"{session}/{project}/{popup_name}" \
-	"working/{project}/default" \
-	"session" "working" \
-	"popup_name" "default"
-test_interpolate \
-	"{var1}/{var2}/{var2}/{var1}" \
-	"value1/value2/value2/value1" \
-	"var1" "value1" \
-	"var2" "value2"
+format="{session}/{project}/{popup_name}"
+expected="working/{project}/default"
+test_interpolate session="working" popup_name="default"
+
+format="{var1}/{var2}/{var2}/{var1}"
+expected="value1/value2/value2/value1"
+test_interpolate var1="value1" var2="value2"
+
+format="{var1}/{var2}/{var2}/{var1}"
+expected="var1=value1/var2=value2/var2=value2/var1=value1"
+test_interpolate var1="var1=value1" var2="var2=value2"

--- a/tests/helper_tests.sh
+++ b/tests/helper_tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CURRENT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # shellcheck source=../src/helpers.sh
 source "$CURRENT_DIR/../src/helpers.sh"
@@ -12,8 +12,8 @@ test_fail() {
 }
 
 test_interpolate() {
-	format="$1" expected="$2"
-	result="$(interpolate "${@:3}" "$format")"
+	format=$1" expected="$2
+	result=$(interpolate "${@:3}" "$format")
 
 	if [[ $result != "$expected" ]]; then
 		test_fail "$result != $expected"

--- a/toggle-popup.tmux
+++ b/toggle-popup.tmux
@@ -5,7 +5,7 @@
 # Authors:  Loi Chyan <loichyan@foxmail.com>
 # License:  MIT OR Apache-2.0
 
-CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CURRENT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # shellcheck source=./src/helpers.sh
 source "$CURRENT_DIR/src/helpers.sh"
@@ -22,10 +22,12 @@ handle_autostart() {
 	# Do not start itself within a popup server
 	if [[ $(showopt @popup-autostart) == "on" && -z ${TMUX_POPUP_SERVER-} ]]; then
 		# Set $TMUX_POPUP_SERVER, used to identify the popup server
-		socket_name="$(get_socket_name)"
+		socket_name=$(get_socket_name)
 		# Propagate user's default shell
-		default_shell="$(get_default_shell)"
-		TMUX_POPUP_SERVER="$socket_name" SHELL="$default_shell" \
+		default_shell=$(get_default_shell)
+		env \
+			TMUX_POPUP_SERVER="$socket_name" \
+			SHELL="$default_shell" \
 			tmux -L "$socket_name" set exit-empty off \; start &
 	fi
 }

--- a/toggle-popup.tmux
+++ b/toggle-popup.tmux
@@ -22,9 +22,9 @@ handle_autostart() {
 	# Do not start itself within a popup server
 	if [[ $(showopt @popup-autostart) == "on" && -z ${TMUX_POPUP_SERVER-} ]]; then
 		# Set $TMUX_POPUP_SERVER, used to identify the popup server
-		socket_name=$(get_socket_name)
+		socket_name=$(showopt @popup-socket-name "$DEFAULT_SOCKET_NAME")
 		# Propagate user's default shell
-		default_shell=$(get_default_shell)
+		default_shell=$(showopt default-shell "$SHELL")
 		env \
 			TMUX_POPUP_SERVER="$socket_name" \
 			SHELL="$default_shell" \


### PR DESCRIPTION
Adopt some tricks to reduce the latency of popup toggles:

- [x] Fetch tmux options in batch
  - [x] Tests pass on Linux
  - [ ] Tests pass on macOS
- [ ] Reduce tmux command parsing calls

This PR reduces latency by ~50% on my tablet, which is relatively slow and lantency-sensitive compared to desktops.

Before:

```console
$ hyperfine "./src/toggle.sh -E --toggle-mode=force-open --on-init='detach'"
Benchmark 1: ./src/toggle.sh -E --toggle-mode=force-open --on-init='detach'
  Time (mean ± σ):     472.5 ms ±  29.3 ms    [User: 55.8 ms, System: 95.7 ms]
  Range (min … max):   426.6 ms … 517.0 ms    10 runs

```

After:

```console
$ hyperfine "./src/toggle.sh -E --toggle-mode=force-open --on-init='detach'"
Benchmark 1: ./src/toggle.sh -E --toggle-mode=force-open --on-init='detach'
  Time (mean ± σ):     287.0 ms ±  14.6 ms    [User: 23.1 ms, System: 39.1 ms]
  Range (min … max):   259.6 ms … 311.9 ms    10 runs
```