### PR TITLE
perf: use `/bin/sh` to launch popup sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,10 @@ are noticeable to end-users since the last release. For developers, this project
 
 ### Changed
 
-- Reduce the lantency of popup toggles by up to 50% ([#33])
+- Reduce the lantency of popup toggles by up to 60% ([#33], [#34])
 
 [#33]: https://github.com/loichyan/tmux-toggle-popup/pull/33
+[#34]: https://github.com/loichyan/tmux-toggle-popup/pull/34
 
 ## [0.4.1] - 2025-05-07
 

--- a/src/eval.sh
+++ b/src/eval.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-script=${__eval:-}
-unset -v __eval
-eval "$script"

--- a/src/toggle.sh
+++ b/src/toggle.sh
@@ -66,6 +66,8 @@ prepare_open() {
 	open_cmds=$(escape "${init_cmds[@]}" "${cmds[@]}" \;)
 }
 
+declare socket_name toggle_mode on_init before_open after_close id_format
+declare default_id_format caller_id_format opened_name default_shell
 main() {
 	batch_get_options \
 		socket_name="#{@popup-socket-name}" \
@@ -76,7 +78,8 @@ main() {
 		id_format="#{E:@popup-id-format}" \
 		default_id_format="$DEFAULT_ID_FORMAT" \
 		caller_id_format="#{@__popup_id_format}" \
-		opened_name="#{@__popup_opened}"
+		opened_name="#{@__popup_opened}" \
+		default_shell="#{default-shell}"
 	name=${name:-$DEFAULT_NAME}
 	toggle_mode=${toggle_mode:-"$DEFAULT_TOGGLE_MODE"}
 	socket_name=${socket_name:-"$DEFAULT_SOCKET_NAME"}
@@ -123,7 +126,6 @@ main() {
 			exec tmux detach >/dev/null
 		elif [[ $toggle_mode == "switch" ]]; then
 			# Reuse the caller's ID format to ensure we open the intended popup
-			# shellcheck disable=SC2154
 			id_format=${caller_id_format}
 			open_args+=("-d") # Create the target session if not exists
 			prepare_open
@@ -148,14 +150,12 @@ main() {
 
 	# Starting from version 3.5, tmux uses the user's `default-shell` to execute
 	# shell commands. However, our scripts are written in `sh`, which may not be
-	# recognized by some shells that are incompatible with it. To address this,
-	# we put the entire script in a temporary env variable and call `./eval.sh`
-	# to run these commands. This approach only requires the user's default
-	# shell to support the `exec` command, which we believe most shells do.
-	tmux display-popup "${popup_args[@]}" \
-		-e TMUX_POPUP_SERVER="$socket_name" \
-		-e __eval="$open_script" \
-		"exec '$CURRENT_DIR/eval.sh'"
+	# recognized by some shells that are incompatible with it. Here we change
+	# the default shell to `/bin/sh` and then revert immediately.
+	tmux set default-shell "/bin/sh"
+	tmux popup "${popup_args[@]}" -e TMUX_POPUP_SERVER="$socket_name" "$open_script" &
+	tmux set default-shell "$default_shell"
+	wait
 
 	# Undo temporary changes
 	if [[ ${#on_cleanup} -gt 0 ]]; then

--- a/src/toggle.sh
+++ b/src/toggle.sh
@@ -143,19 +143,19 @@ main() {
 		eval "tmux -C $(escape "${cmds[@]}")" >/dev/null
 	fi
 
-	# Expand the configured ID format
 	open_args+=("-A") # Create the target session and attach to it
 	prepare_open
-	open_script="exec tmux -L '$socket_name' $open_cmds >/dev/null"
 
 	# Starting from version 3.5, tmux uses the user's `default-shell` to execute
 	# shell commands. However, our scripts are written in `sh`, which may not be
 	# recognized by some shells that are incompatible with it. Here we change
 	# the default shell to `/bin/sh` and then revert immediately.
-	tmux set default-shell "/bin/sh"
-	tmux popup "${popup_args[@]}" -e TMUX_POPUP_SERVER="$socket_name" "$open_script" &
-	tmux set default-shell "$default_shell"
-	wait
+	tmux \
+		set default-shell "/bin/sh" \; \
+		popup "${popup_args[@]}" -e TMUX_POPUP_SERVER="$socket_name" "
+		tmux set default-shell '$default_shell'
+		exec tmux -L '$socket_name' $open_cmds >/dev/null
+	"
 
 	# Undo temporary changes
 	if [[ ${#on_cleanup} -gt 0 ]]; then


### PR DESCRIPTION
Temporarily change `default-shell` to `/bin/sh` to execute the shell script that launches popup sessions:

1. It addresses the issue described in #14.
2. It should not bring the regressions reported in #15.
3. It also provides a performance boost when opening a popup, since the user shell may take some time to customize before it's ready to run commands.

On my laptop, this PR reduces the latency by ~40% when opening popups.

Before:

```console
$ hyperfine --shell=/bin/sh --warmup 3 "./src/toggle.sh -E --toggle-mode=force-open --on-init='detach'"
Benchmark 1: ./src/toggle.sh -E --toggle-mode=force-open --on-init='detach'
  Time (mean ± σ):      48.7 ms ±   2.0 ms    [User: 7.2 ms, System: 7.7 ms]
  Range (min … max):    44.4 ms …  55.0 ms    61 runs
```

After:

```console
$ hyperfine --shell=/bin/sh --warmup 3 "./src/toggle.sh -E --toggle-mode=force-open --on-init='detach'"
Benchmark 1: ./src/toggle.sh -E --toggle-mode=force-open --on-init='detach'
  Time (mean ± σ):      27.7 ms ±   4.7 ms    [User: 7.6 ms, System: 8.6 ms]
  Range (min … max):    24.2 ms …  43.9 ms    66 runs
```
