### PR TITLE
feat: support opening popups with the caller path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,12 +32,17 @@ are noticeable to end-users since the last release. For developers, this project
 
 ## [Unreleased]
 
+### Added
+
+- Support using `{popup_caller_path}` and `{popup_caller_pane_path}` to open popups ([#35])
+
 ### Changed
 
 - Reduce the lantency of popup toggles by up to 60% ([#33], [#34])
 
 [#33]: https://github.com/loichyan/tmux-toggle-popup/pull/33
 [#34]: https://github.com/loichyan/tmux-toggle-popup/pull/34
+[#35]: https://github.com/loichyan/tmux-toggle-popup/pull/35
 
 ## [0.4.1] - 2025-05-07
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ Options:
 
   --name <name>               Popup name [Default: "default"]
   --id <id>                   Popup ID, default to the expanded ID format
-  --toggle-mode <mode>        Action to handle nested calls [Default: "switch"]
   --toggle-key <key>          Bind additional keys to close the opened popup
   -[BCE]                      Flags passed to display-popup
   -[bcdehsStTwxy] <value>     Options passed to display-popup
@@ -104,11 +103,12 @@ Popup Options:
 
   Override global popup options on the fly.
 
-  --socket-name <value>       Socket name
   --id-format <value>         Popup ID format
   --on-init <hook>            Command to run on popup initialization
   --before-open <hook>        Hook to run before opening the popup
   --after-close <hook>        Hook to run after closing the popup
+  --toggle-mode <mode>        Action to handle nested calls [Default: "switch"]
+  --socket-name <value>       Socket name
 
 Examples:
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Create keybindings to toggle your preferred shell and
 [lazygit](https://github.com/jesseduffield/lazygit):
 
 ```tmux
-bind -n M-t run "#{@popup-toggle} -Ed'#{pane_current_path}' -w75% -h75%"
-bind -n M-g run "#{@popup-toggle} -Ed'#{pane_current_path}' -w90% -h90% --name=lazygit lazygit"
+bind -n M-t run "#{@popup-toggle} -w75% -h75% -Ed'{popup_caller_pane_path}'"
+bind -n M-g run "#{@popup-toggle} -w90% -h90% -Ed'{popup_caller_pane_path}' --name=lazygit lazygit"
 ```
 
 ## ⌨️ Commands
@@ -69,6 +69,11 @@ namely when invoked in an opened popup with a different name specified:
 2. `force-close`: Close the opened popup window. This is the expected behavior when the name matches
    or no arguments are provided.
 3. `force-open`: Open a new popup window within the current one, i.e., popup-in-popup.
+
+Additionally, you may use `{popup_caller_path}` and `{popup_caller_pane_path}` to specify the
+working directory of popups, which will be substituted with the path of the caller session and the
+path of the caller pane, respectively. They serve as context-aware alternatives to `#{session_path}`
+and `#{pane_current_path}`, and are therefore recommended for use instead of the latter.
 
 If you have set popup keybindings in your `.tmux.conf`, which should be loaded in both your default
 server and the popup server, there's no need to worry about the toggle keys. For instance, if `M-t`
@@ -107,13 +112,7 @@ Popup Options:
 
 Examples:
 
-  toggle.sh -Ed'#{pane_current_path}' --name=bash bash
-```
-
-**Example**:
-
-```tmux
-bind -n M-t run "#{@popup-toggle} -Ed'#{pane_current_path}' -w75% -h75%"
+  toggle.sh -Ed'{popup_caller_pane_path}' --name=bash bash
 ```
 
 ### `@popup-focus`

--- a/src/focus.sh
+++ b/src/focus.sh
@@ -5,7 +5,6 @@ CURRENT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=./helpers.sh
 source "$CURRENT_DIR/helpers.sh"
 
-declare OPT OPTARG OPTIND=1 mode=I programs
 usage() {
 	cat <<-EOF
 		Usage:
@@ -38,7 +37,9 @@ check_program() {
 	return 1
 }
 
+declare mode=I programs
 main() {
+	declare OPT OPTARG OPTIND=1
 	while getopts :-: OPT; do
 		if [[ $OPT == '-' ]]; then OPT=${OPTARG%%=*}; fi
 		case "$OPT" in

--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -20,7 +20,7 @@ die_badopt() {
 showopt() {
 	local v
 	v=$(tmux show -gqv "$1")
-	echo "${v:-"$2"}"
+	echo "${v:-$2}"
 }
 
 # Fetches tmux options in batch. Each argument may be specified in the syntax

--- a/src/toggle.sh
+++ b/src/toggle.sh
@@ -94,10 +94,10 @@ main() {
 		session_path="#{session_path}" \
 		pane_path="#{pane_current_path}"
 	name=${name:-$DEFAULT_NAME}
-	socket_name=${socket_name:-"$DEFAULT_SOCKET_NAME"}
-	toggle_mode=${toggle_mode:-"$DEFAULT_TOGGLE_MODE"}
-	on_init=${on_init:-"$DEFAULT_ON_INIT"}
-	id_format="${id_format:-"$default_id_format"}"
+	socket_name=${socket_name:-$DEFAULT_SOCKET_NAME}
+	toggle_mode=${toggle_mode:-$DEFAULT_TOGGLE_MODE}
+	on_init=${on_init:-$DEFAULT_ON_INIT}
+	id_format="${id_format:-$default_id_format}"
 
 	while getopts :-:BCEb:c:d:e:h:s:S:t:T:w:x:y: OPT; do
 		if [[ $OPT == '-' ]]; then OPT=${OPTARG%%=*}; fi

--- a/src/toggle.sh
+++ b/src/toggle.sh
@@ -18,7 +18,6 @@ usage() {
 
 		  --name <name>               Popup name [Default: "$DEFAULT_NAME"]
 		  --id <id>                   Popup ID, default to the expanded ID format
-		  --toggle-mode <mode>        Action to handle nested calls [Default: "$DEFAULT_TOGGLE_MODE"]
 		  --toggle-key <key>          Bind additional keys to close the opened popup
 		  -[BCE]                      Flags passed to display-popup
 		  -[bcdehsStTwxy] <value>     Options passed to display-popup
@@ -27,11 +26,12 @@ usage() {
 
 		  Override global popup options on the fly.
 
-		  --socket-name <value>       Socket name [Default: "$DEFAULT_SOCKET_NAME"]
 		  --id-format <value>         Popup ID format [Default: "$DEFAULT_ID_FORMAT"]
 		  --on-init <hook>            Command to run on popup initialization [Default: "$DEFAULT_ON_INIT"]
 		  --before-open <hook>        Hook to run before opening the popup [Default: ""]
 		  --after-close <hook>        Hook to run after closing the popup [Default: ""]
+		  --toggle-mode <mode>        Action to handle nested calls [Default: "$DEFAULT_TOGGLE_MODE"]
+		  --socket-name <value>       Socket name [Default: "$DEFAULT_SOCKET_NAME"]
 
 		Examples:
 
@@ -80,17 +80,18 @@ prepare_open() {
 	open_cmds+=("${cmds[@]}")
 }
 
-declare name socket_name toggle_mode on_init before_open after_close id_format
+declare name id id_format toggle_keys popup_dir
+declare on_init before_open after_close toggle_mode socket_name
 declare opened_name caller_id_format caller_path caller_pane_path
-declare default_id_format default_shell session_path pane_path popup_dir
+declare default_id_format default_shell session_path pane_path
 main() {
 	batch_get_options \
-		socket_name="#{@popup-socket-name}" \
-		toggle_mode="#{@popup-toggle-mode}" \
+		id_format="#{E:@popup-id-format}" \
 		on_init="#{@popup-on-init}" \
 		before_open="#{@popup-before-open}" \
 		after_close="#{@popup-after-close}" \
-		id_format="#{E:@popup-id-format}" \
+		toggle_mode="#{@popup-toggle-mode}" \
+		socket_name="#{@popup-socket-name}" \
 		opened_name="#{@__popup_opened}" \
 		caller_id_format="#{@__popup_id_format}" \
 		caller_path="#{@__popup_caller_path}" \
@@ -100,10 +101,10 @@ main() {
 		session_path="#{session_path}" \
 		pane_path="#{pane_current_path}"
 	name=${name:-$DEFAULT_NAME}
-	socket_name=${socket_name:-$DEFAULT_SOCKET_NAME}
-	toggle_mode=${toggle_mode:-$DEFAULT_TOGGLE_MODE}
-	on_init=${on_init:-$DEFAULT_ON_INIT}
 	id_format="${id_format:-$default_id_format}"
+	on_init=${on_init:-$DEFAULT_ON_INIT}
+	toggle_mode=${toggle_mode:-$DEFAULT_TOGGLE_MODE}
+	socket_name=${socket_name:-$DEFAULT_SOCKET_NAME}
 
 	while getopts :-:BCEb:c:d:e:h:s:S:t:T:w:x:y: OPT; do
 		if [[ $OPT == '-' ]]; then OPT=${OPTARG%%=*}; fi
@@ -114,8 +115,8 @@ main() {
 		d) popup_dir=$OPTARG ;;
 		# Forward environment overrides to popup sessions
 		e) open_args+=("-e" "$OPTARG") ;;
-		name | toggle-key | socket-name | id-format | id | \
-			toggle-mode | on-init | before-open | after-close)
+		name | id | id-format | toggle-key | \
+			on-init | before-open | after-close | toggle-mode | socket-name)
 			OPTARG=${OPTARG:${#OPT}}
 			if [[ ${OPTARG::1} == '=' ]]; then
 				# Handle syntax: `--name=value`

--- a/tests/command_parser_tests.sh
+++ b/tests/command_parser_tests.sh
@@ -8,12 +8,6 @@ source "$CURRENT_DIR/helpers.sh"
 # shellcheck source=../src/helpers.sh
 source "$CURRENT_DIR/../src/helpers.sh"
 
-# Simulates Bash arguments interpretation.
-reparse_commands() {
-	# shellcheck disable=SC2046
-	eval printf '%s\\n' $(cat)
-}
-
 test_parse_commands() {
 	parse_cmds "$1"
 	shift

--- a/toggle-popup.tmux
+++ b/toggle-popup.tmux
@@ -12,7 +12,7 @@ source "$CURRENT_DIR/src/helpers.sh"
 # shellcheck source=./src/variables.sh
 source "$CURRENT_DIR/src/variables.sh"
 
-export_commands() {
+handle_exports() {
 	tmux \
 		set -g "@popup-toggle" "$CURRENT_DIR/src/toggle.sh" \; \
 		set -g "@popup-focus" "$CURRENT_DIR/src/focus.sh" \;
@@ -36,10 +36,10 @@ main() {
 		autostart="#{@popup-autostart}" \
 		socket_name="#{@popup-socket-name}" \
 		default_shell="#{default-shell}"
-	socket_name=${socket_name:-"$DEFAULT_SOCKET_NAME"}
-	default_shell=${default_shell:-"$SHELL"}
+	socket_name=${socket_name:-$DEFAULT_SOCKET_NAME}
+	default_shell=${default_shell:-$SHELL}
 
-	export_commands
+	handle_exports
 	handle_autostart
 }
 main


### PR DESCRIPTION
Support using `{popup_caller_path}` and `{popup_caller_pane_path}` to open popups. These two variables are equivalent (though not necessarily identical) to `#{session_path}` and `#{pane_current_path}`. While the difference can be quite subtle, consider the following procedure:

```sh
# Simulates opening a popup and then switching to another
declare dir
test() {
    name=${1}
    # 1) Open a new popup window
    tmux run "#{@popup-toggle} -Ed'$dir' --toggle-mode=force-open --name=${name}_1 bash" &
    sleep 2
    tmux -Lpopup send -l "echo -e '\x1b[1;31mtest $name with directory=$dir\x1b[0m'"
    tmux -Lpopup send Enter
    tmux -Lpopup send -l 'echo -e "\x1b[1;31m>>> PWD=$PWD\x1b[0m"'
    tmux -Lpopup send Enter
    # 2) Change the working dir
    tmux -Lpopup send -l 'cd $(mktemp -d)'
    tmux -Lpopup send Enter
    tmux -Lpopup send -l 'echo -e "\x1b[1;31m>>> PWD=$PWD\x1b[0m"'
    tmux -Lpopup send Enter
    tmux -Lpopup send -l 'echo -e "\x1b[1;31m>>> #{pane_current_path} changed\x1b[0m"'
    tmux -Lpopup send Enter
    sleep 10

    # 3) Switch to another popup
    tmux -Lpopup run "#{@popup-toggle} -Ed'$dir' --toggle-mode=switch --name=${name}_2 bash"
    sleep 2
    tmux -Lpopup send -l 'echo -e "\x1b[1;31m>>> PWD=$PWD\x1b[0m"'
    tmux -Lpopup send Enter
    tmux -Lpopup send -l 'echo -e "\x1b[1;31m>>> where am I now?\x1b[0m"'
    tmux -Lpopup send Enter
    sleep 10

    tmux -Lpopup run "#{@popup-toggle}"
}
dir='#{pane_current_path}' test "pane_current_path"
dir='{popup_caller_pane_path}' test "caller_pane_path"
```

After running it, you should observe:

- In the first test, the second popup opens in the same temporary directory as the first one.
- In the second test, the second popup opens in the same directory as the caller pane.

The latter behavior should be the desired outcome in most cases.
