### PR TITLE
feat: support disabling a hook explicitly

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Doc | Update PR numbers
         if: github.event_name == 'pull_request'
         run: |
-          sed -i 's/\([^`]\){{PRNUM}}\([^`]\)/\1${{ github.event.number }}\2/g' CHANGELOG.md
+          sed -i 's/\([^`]\?\){{PRNUM}}\([^`]\?\)/\1${{ github.event.number }}\2/g' CHANGELOG.md
 
       - name: Post Doc | Commit changes
         if: github.event_name == 'pull_request'

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -40,6 +40,20 @@ jobs:
       - name: Check | Test suite
         run: ./run_tests.sh
 
+      - name: Post Check | Update PR numbers
+        if: github.event_name == 'pull_request'
+        run: |
+          sed -i 's/\([^`]\){{PRNUM}}\([^`]\)/\1${{ github.event.number }}\2/g' CHANGELOG.md
+
+      - name: Post Check | Commit changes
+        if: github.event_name == 'pull_request'
+        uses: stefanzweifel/git-auto-commit-action@v6
+        with:
+          commit_message: "docs: update pull request numbers"
+          commit_user_name: github-actions[bot]
+          commit_user_email: github-actions[bot]@users.noreply.github.com
+          commit_author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+
   # How to create a new GitHub release?
   # 1. Create a release branch named "release/<tag>".
   # 2. Open a PR from the branch, including the release note in the PR body.

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -44,6 +44,8 @@ jobs:
     name: Update changelog
     needs: [check]
     if: github.event_name == 'pull_request'
+    permissions:
+      contents: write # need to commit changes
     runs-on: ubuntu-latest
     steps:
       - name: Setup | Checkout

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -50,6 +50,7 @@ jobs:
     steps:
       - name: Setup | Checkout
         uses: actions/checkout@v4
+        with: { ref: "${{ github.head_ref }}" }
 
       - name: Doc | Update PR numbers
         if: github.event_name == 'pull_request'

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -40,12 +40,21 @@ jobs:
       - name: Check | Test suite
         run: ./run_tests.sh
 
-      - name: Post Check | Update PR numbers
+  changelog:
+    name: Update changelog
+    needs: [check]
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup | Checkout
+        uses: actions/checkout@v4
+
+      - name: Doc | Update PR numbers
         if: github.event_name == 'pull_request'
         run: |
           sed -i 's/\([^`]\){{PRNUM}}\([^`]\)/\1${{ github.event.number }}\2/g' CHANGELOG.md
 
-      - name: Post Check | Commit changes
+      - name: Post Doc | Commit changes
         if: github.event_name == 'pull_request'
         uses: stefanzweifel/git-auto-commit-action@v6
         with:
@@ -61,7 +70,7 @@ jobs:
   # 4. Publish the release when it's ready.
   release:
     name: Create GitHub release
-    needs: [check]
+    needs: [check, changelog]
     if: startsWith(github.head_ref, 'release/') && github.repository == 'loichyan/tmux-toggle-popup'
     permissions:
       contents: write # need to update release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ are noticeable to end-users since the last release. For developers, this project
 [#33]: https://github.com/loichyan/tmux-toggle-popup/pull/33
 [#34]: https://github.com/loichyan/tmux-toggle-popup/pull/34
 [#35]: https://github.com/loichyan/tmux-toggle-popup/pull/35
-[#36]: https://github.com/loichyan/tmux-toggle-popup/pull/{{PRNUM}}
+[#36]: https://github.com/loichyan/tmux-toggle-popup/pull/36
 
 ## [0.4.1] - 2025-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ are noticeable to end-users since the last release. For developers, this project
 
 - (**breaking**) Always place breaking changes at the top.
 - Append other changes in chronological order under the relevant subsections.
+- Additionally, you may use `{{PPNUM}}` as a placeholder for the number of a new pull
+  request, which will be substituted with the actual number through GitHub Actions.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ are noticeable to end-users since the last release. For developers, this project
 ### Added
 
 - Support using `{popup_caller_path}` and `{popup_caller_pane_path}` to open popups ([#35])
-- Support using `nop` to disable a hook explicitly ([#{{PRNUM}}])
+- Support using `nop` to disable a hook explicitly ([#36])
 
 ### Changed
 
@@ -46,7 +46,7 @@ are noticeable to end-users since the last release. For developers, this project
 [#33]: https://github.com/loichyan/tmux-toggle-popup/pull/33
 [#34]: https://github.com/loichyan/tmux-toggle-popup/pull/34
 [#35]: https://github.com/loichyan/tmux-toggle-popup/pull/35
-[#{{PRNUM}}]: https://github.com/loichyan/tmux-toggle-popup/pull/{{PRNUM}}
+[#36]: https://github.com/loichyan/tmux-toggle-popup/pull/{{PRNUM}}
 
 ## [0.4.1] - 2025-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ are noticeable to end-users since the last release. For developers, this project
 ### Added
 
 - Support using `{popup_caller_path}` and `{popup_caller_pane_path}` to open popups ([#35])
+- Support using `nop` to disable a hook explicitly ([#{{PRNUM}}])
 
 ### Changed
 
@@ -45,6 +46,7 @@ are noticeable to end-users since the last release. For developers, this project
 [#33]: https://github.com/loichyan/tmux-toggle-popup/pull/33
 [#34]: https://github.com/loichyan/tmux-toggle-popup/pull/34
 [#35]: https://github.com/loichyan/tmux-toggle-popup/pull/35
+[#{{PRNUM}}]: https://github.com/loichyan/tmux-toggle-popup/pull/{{PRNUM}}
 
 ## [0.4.1] - 2025-05-07
 

--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -56,10 +56,15 @@ escape_session_name() {
 }
 
 # Parses tmux commands, assigning the tokens to an array named `cmds`.
+#
+# It returns 1 if the given string does not contain any valid tmux commands.
 declare cmds
 parse_cmds() {
+	if [[ -z $1 || $1 == "nop" ]]; then
+		return 1
+	fi
 	# shellcheck disable=SC2034
-	IFS=$'\n' read -d '' -ra cmds < <(echo "$*" | xargs printf "%s\n") || true
+	IFS=$'\n' read -d '' -ra cmds < <(echo "$1" | xargs printf "%s\n") || true
 }
 
 # Expands the provided tmux FORMAT string.

--- a/src/toggle.sh
+++ b/src/toggle.sh
@@ -75,8 +75,9 @@ prepare_open() {
 		on_cleanup+=(unbind $k \;)
 	done
 
-	parse_cmds "$on_init"
-	open_cmds+=("${cmds[@]}")
+	if parse_cmds "$on_init"; then
+		open_cmds+=("${cmds[@]}")
+	fi
 }
 
 declare name id id_format toggle_keys open_args open_dir program display_args
@@ -156,8 +157,7 @@ main() {
 	fi
 
 	# Run hook: before-open
-	if [[ -n $before_open ]]; then
-		parse_cmds "$before_open"
+	if parse_cmds "$before_open"; then
 		tmux -C "${cmds[@]}" >/dev/null
 	fi
 
@@ -185,8 +185,7 @@ main() {
 	fi
 
 	# Run hook: after-close
-	if [[ -n $after_close ]]; then
-		parse_cmds "$after_close"
+	if parse_cmds "$after_close"; then
 		tmux -C "${cmds[@]}" >/dev/null
 	fi
 }


### PR DESCRIPTION
Currently, if `@popup-on-init` is set to empty, the default value is used as a fallback. This makes it impossible to disable that hook. After this PR, you can set it to `nop` to disable it explicitly.