### PR TITLE
refactor: improve error handling and logging

### DIFF
--- a/src/focus.sh
+++ b/src/focus.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+set -e
 CURRENT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # shellcheck source=./helpers.sh

--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -36,8 +36,10 @@ batch_get_options() {
 	delimiter=${delimiter:-"EOF@$RANDOM"} # generate a random delimiter
 	set -- "${vars[@]}"
 	while IFS= read -r line; do
-		if [[ $line != "$delimiter" ]]; then
-			[[ -n $line ]] && val+=("$line")
+		if [[ -z $line ]]; then
+			:
+		elif [[ $line != "$delimiter" ]]; then
+			val+=("$line")
 		else
 			printf -v "$1" "%s" "${val[*]}" # replace line breaks with spaces
 			val=()

--- a/src/toggle.sh
+++ b/src/toggle.sh
@@ -64,7 +64,7 @@ prepare_open() {
 		open_cmds+=(switch -t "$popup_id" \;)
 	fi
 
-	open_cmds+=(set @__popup_opened "$name" \;)
+	open_cmds+=(set @__popup_name "$name" \;)
 	open_cmds+=(set @__popup_id_format "$id_format" \;)
 	open_cmds+=(set @__popup_caller_path "$caller_path" \;)
 	open_cmds+=(set @__popup_caller_pane_path "$caller_pane_path" \;)
@@ -93,7 +93,7 @@ main() {
 		after_close="#{@popup-after-close}" \
 		toggle_mode="#{@popup-toggle-mode}" \
 		socket_name="#{@popup-socket-name}" \
-		opened_name="#{@__popup_opened}" \
+		opened_name="#{@__popup_name}" \
 		caller_id_format="#{@__popup_id_format}" \
 		caller_path="#{@__popup_caller_path}" \
 		caller_pane_path="#{@__popup_caller_pane_path}" \
@@ -172,7 +172,7 @@ main() {
 	# and propagate user's default shell.
 	open_script+="; export TMUX_POPUP_SERVER='$socket_name' SHELL='$default_shell'"
 	# Suppress stdout to hide the `[detached] ...` message
-	open_script+="; exec tmux $(escape -L "$socket_name" "${open_cmds[@]}") >/dev/null"
+	open_script+="; exec tmux -L '$socket_name' $(escape "${open_cmds[@]}") >/dev/null"
 
 	# Starting from version 3.5, tmux uses the user's `default-shell` to execute
 	# shell commands. However, our scripts require sh(1), which may not be

--- a/toggle-popup.tmux
+++ b/toggle-popup.tmux
@@ -22,8 +22,8 @@ handle_exports() {
 handle_autostart() {
 	# Do not start itself within a popup server
 	if [[ $autostart == "on" && -z $TMUX_POPUP_SERVER ]]; then
-		# 1) Set $TMUX_POPUP_SERVER, used to identify the popup server.
-		# 2) Propagate user's default shell.
+		# Set $TMUX_POPUP_SERVER so as to identify the popup server,
+		# and propagate user's default shell.
 		env \
 			TMUX_POPUP_SERVER="$socket_name" \
 			SHELL="$default_shell" \

--- a/toggle-popup.tmux
+++ b/toggle-popup.tmux
@@ -5,6 +5,7 @@
 # Authors:  Loi Chyan <loichyan@foxmail.com>
 # License:  MIT OR Apache-2.0
 
+set -e
 CURRENT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # shellcheck source=./src/helpers.sh
@@ -18,7 +19,6 @@ handle_exports() {
 		set -g "@popup-focus" "$CURRENT_DIR/src/focus.sh" \;
 }
 
-declare autostart socket_name default_shell
 handle_autostart() {
 	# Do not start itself within a popup server
 	if [[ $autostart == "on" && -z $TMUX_POPUP_SERVER ]]; then
@@ -31,6 +31,7 @@ handle_autostart() {
 	fi
 }
 
+declare autostart socket_name default_shell
 main() {
 	batch_get_options \
 		autostart="#{@popup-autostart}" \


### PR DESCRIPTION
1. Stop running hooks in control mode.
2. Printing stdout when running hooks.
3. Keeps most stderr outputs. But they can still be dropped by `run-shell` unless `-E` is specified.
4. Enable the `-e` flag in exported scripts so as to catch potential errors.