### PR TITLE
perf: open popup window and run hooks in a single execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ follows <https://www.conventionalcommits.org/en/v1.0.0/> to track changes.
 ### Changed
 
 - The `before-open` and `after-close` hooks are called in the same execution
-  that opens a popup window. This should rarely have side effects ([#{{PRNUM}}])
+  that opens a popup window. This should rarely have side effects ([#46])
 
 ### Fixed
 
@@ -57,7 +57,7 @@ follows <https://www.conventionalcommits.org/en/v1.0.0/> to track changes.
 [#43]: https://github.com/loichyan/tmux-toggle-popup/pull/43
 [#44]: https://github.com/loichyan/tmux-toggle-popup/pull/44
 [#45]: https://github.com/loichyan/tmux-toggle-popup/pull/45
-[#{{PRNUM}}]: https://github.com/loichyan/tmux-toggle-popup/pull/{{PRNUM}}
+[#46]: https://github.com/loichyan/tmux-toggle-popup/pull/46
 [NixOS/nixpkgs#428294]: https://github.com/NixOS/nixpkgs/pull/428294
 [@szaffarano]: https://github.com/szaffarano
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,11 @@ follows <https://www.conventionalcommits.org/en/v1.0.0/> to track changes.
   [@szaffarano])
 - Support specifying the socket path for the popup server ([#43])
 
+### Changed
+
+- The `before-open` and `after-close` hooks are called in the same execution
+  that opens a popup window. This should rarely have side effects ([#{{PRNUM}}])
+
 ### Fixed
 
 - Support OSX's ancient Bash ([#44])
@@ -52,6 +57,7 @@ follows <https://www.conventionalcommits.org/en/v1.0.0/> to track changes.
 [#43]: https://github.com/loichyan/tmux-toggle-popup/pull/43
 [#44]: https://github.com/loichyan/tmux-toggle-popup/pull/44
 [#45]: https://github.com/loichyan/tmux-toggle-popup/pull/45
+[#{{PRNUM}}]: https://github.com/loichyan/tmux-toggle-popup/pull/{{PRNUM}}
 [NixOS/nixpkgs#428294]: https://github.com/NixOS/nixpkgs/pull/428294
 [@szaffarano]: https://github.com/szaffarano
 

--- a/src/toggle_tests/open_nested_popup.stdout
+++ b/src/toggle_tests/open_nested_popup.stdout
@@ -4,22 +4,19 @@ before-open
 ;
 run
 #{@before_open}
-<<<TMUX:END(1)
-
->>>TMUX:BEGIN(2)
+;
 set
 default-shell
 /bin/sh
 ;
-popup
-tmux set default-shell '/usr/bin/fish'; export TMUX_POPUP_SERVER='popup_server2' SHELL='/usr/bin/fish'; exec tmux -S socket/path/popup_server2 new -As pane/path/p_open_nested_2 \; set @__popup_name p_open_nested_2 \; set @__popup_id_format pane/path/\{popup_name\} \; set @__popup_caller_path working/session/path \; set @__popup_caller_pane_path working/pane/path \; display on-init \; run \#\{@on_init\}  >/dev/null
-<<<TMUX:END(2)
-
->>>TMUX:BEGIN(3)
+display-popup
+tmux set default-shell '/usr/bin/fish' ;export TMUX_POPUP_SERVER='popup_server2' ;export SHELL='/usr/bin/fish' ;exec tmux -S socket/path/popup_server2 new -As pane/path/p_open_nested_2 \; set @__popup_name p_open_nested_2 \; set @__popup_id_format pane/path/\{popup_name\} \; set @__popup_caller_path working/session/path \; set @__popup_caller_pane_path working/pane/path \; display on-init \; run \#\{@on_init\}  >/dev/null
+;
 display
 after-close
 ;
 run
 #{@after_close}
-<<<TMUX:END(3)
+;
+<<<TMUX:END(1)
 

--- a/src/toggle_tests/open_nested_with_toggle_key.stdout
+++ b/src/toggle_tests/open_nested_with_toggle_key.stdout
@@ -4,22 +4,19 @@ before-open
 ;
 run
 #{@before_open}
-<<<TMUX:END(1)
-
->>>TMUX:BEGIN(2)
+;
 set
 default-shell
 /bin/sh
 ;
-popup
-tmux set default-shell '/usr/bin/fish'; export TMUX_POPUP_SERVER='popup_server2' SHELL='/usr/bin/fish'; exec tmux -S socket/path/popup_server2 new -As pane/path/p_nested_toggle_key_2 \; set @__popup_name p_nested_toggle_key_2 \; set @__popup_id_format pane/path/\{popup_name\} \; set @__popup_caller_path working/session/path \; set @__popup_caller_pane_path working/pane/path \; bind -n M-o run \#\{@popup-toggle\}\ --name=p_nested_toggle_key_2\ --toggle-key=-n\\\ M-o\  \; display on-init \; run \#\{@on_init\}  >/dev/null
-<<<TMUX:END(2)
-
->>>TMUX:BEGIN(3)
+display-popup
+tmux set default-shell '/usr/bin/fish' ;export TMUX_POPUP_SERVER='popup_server2' ;export SHELL='/usr/bin/fish' ;exec tmux -S socket/path/popup_server2 new -As pane/path/p_nested_toggle_key_2 \; set @__popup_name p_nested_toggle_key_2 \; set @__popup_id_format pane/path/\{popup_name\} \; set @__popup_caller_path working/session/path \; set @__popup_caller_pane_path working/pane/path \; bind -n M-o run \#\{@popup-toggle\}\ --name=p_nested_toggle_key_2\ --toggle-key=-n\\\ M-o\  \; display on-init \; run \#\{@on_init\}  >/dev/null
+;
 display
 after-close
 ;
 run
 #{@after_close}
-<<<TMUX:END(3)
+;
+<<<TMUX:END(1)
 

--- a/src/toggle_tests/open_popup.stdout
+++ b/src/toggle_tests/open_popup.stdout
@@ -4,22 +4,19 @@ before-open
 ;
 run
 #{@before_open}
-<<<TMUX:END(1)
-
->>>TMUX:BEGIN(2)
+;
 set
 default-shell
 /bin/sh
 ;
-popup
-tmux set default-shell '/usr/bin/fish'; export TMUX_POPUP_SERVER='popup_server2' SHELL='/usr/bin/fish'; exec tmux -S socket/path/popup_server2 new -As pane/path/p_open \; set @__popup_name p_open \; set @__popup_id_format pane/path/\{popup_name\} \; set @__popup_caller_path working/session/path \; set @__popup_caller_pane_path working/pane/path \; display on-init \; run \#\{@on_init\}  >/dev/null
-<<<TMUX:END(2)
-
->>>TMUX:BEGIN(3)
+display-popup
+tmux set default-shell '/usr/bin/fish' ;export TMUX_POPUP_SERVER='popup_server2' ;export SHELL='/usr/bin/fish' ;exec tmux -S socket/path/popup_server2 new -As pane/path/p_open \; set @__popup_name p_open \; set @__popup_id_format pane/path/\{popup_name\} \; set @__popup_caller_path working/session/path \; set @__popup_caller_pane_path working/pane/path \; display on-init \; run \#\{@on_init\}  >/dev/null
+;
 display
 after-close
 ;
 run
 #{@after_close}
-<<<TMUX:END(3)
+;
+<<<TMUX:END(1)
 

--- a/src/toggle_tests/open_with_toggle_key.stdout
+++ b/src/toggle_tests/open_with_toggle_key.stdout
@@ -4,18 +4,23 @@ before-open
 ;
 run
 #{@before_open}
-<<<TMUX:END(1)
-
->>>TMUX:BEGIN(2)
+;
 set
 default-shell
 /bin/sh
 ;
-popup
-tmux set default-shell '/usr/bin/fish'; export TMUX_POPUP_SERVER='popup_server2' SHELL='/usr/bin/fish'; exec tmux -S socket/path/popup_server2 new -As pane/path/p_toggle_key \; set @__popup_name p_toggle_key \; set @__popup_id_format pane/path/\{popup_name\} \; set @__popup_caller_path working/session/path \; set @__popup_caller_pane_path working/pane/path \; bind -T root M-p run \#\{@popup-toggle\}\ --name=p_toggle_key\ --toggle-key=-T\\\ root\\\ M-p\ --toggle-key=-n\\\ M-o\  \; bind -n M-o run \#\{@popup-toggle\}\ --name=p_toggle_key\ --toggle-key=-T\\\ root\\\ M-p\ --toggle-key=-n\\\ M-o\  \; display on-init \; run \#\{@on_init\}  >/dev/null
-<<<TMUX:END(2)
+display-popup
+tmux set default-shell '/usr/bin/fish' ;export TMUX_POPUP_SERVER='popup_server2' ;export SHELL='/usr/bin/fish' ;exec tmux -S socket/path/popup_server2 new -As pane/path/p_toggle_key \; set @__popup_name p_toggle_key \; set @__popup_id_format pane/path/\{popup_name\} \; set @__popup_caller_path working/session/path \; set @__popup_caller_pane_path working/pane/path \; bind -T root M-p run \#\{@popup-toggle\}\ --name=p_toggle_key\ --toggle-key=-T\\\ root\\\ M-p\ --toggle-key=-n\\\ M-o\  \; bind -n M-o run \#\{@popup-toggle\}\ --name=p_toggle_key\ --toggle-key=-T\\\ root\\\ M-p\ --toggle-key=-n\\\ M-o\  \; display on-init \; run \#\{@on_init\}  >/dev/null
+;
+display
+after-close
+;
+run
+#{@after_close}
+;
+<<<TMUX:END(1)
 
->>>TMUX:BEGIN(3)
+>>>TMUX:BEGIN(2)
 -N
 -S
 socket/path/popup_server2
@@ -28,13 +33,5 @@ unbind
 -n
 M-o
 ;
-<<<TMUX:END(3)
-
->>>TMUX:BEGIN(4)
-display
-after-close
-;
-run
-#{@after_close}
-<<<TMUX:END(4)
+<<<TMUX:END(2)
 

--- a/toggle-popup.tmux
+++ b/toggle-popup.tmux
@@ -22,8 +22,8 @@ handle_exports() {
 handle_autostart() {
 	# Do not start itself within a popup server
 	if [[ $autostart == "on" && -z $TMUX_POPUP_SERVER ]]; then
-		# Set $TMUX_POPUP_SERVER so as to identify the popup server,
-		# and propagate user's default shell.
+		# Set $TMUX_POPUP_SERVER to identify the popup server.
+		# Propagate user's default shell.
 		env \
 			TMUX_POPUP_SERVER="$socket_name" \
 			SHELL="$default_shell" \


### PR DESCRIPTION
Generally, adding tmux calls will also increase the latency when opening a popup window, as shown below:

Before this PR:

```console
$ hyperfine --shell=/bin/sh --warmup=3 "./src/toggle.sh -E --before-open='run true' --on-init='detach' --after-close='run true'"
Benchmark 1: ./src/toggle.sh -E --before-open='run true' --on-init='detach' --after-close='run true'
  Time (mean ± σ):      64.1 ms ±  17.8 ms    [User: 17.1 ms, System: 24.2 ms]
  Range (min … max):    38.5 ms …  94.8 ms    70 runs
```

After:

```console
$ hyperfine --shell=/bin/sh --warmup=3 "./src/toggle.sh -E --before-open='run true' --on-init='detach' --after-close='run true'"
Benchmark 1: ./src/toggle.sh -E --before-open='run true' --on-init='detach' --after-close='run true'
  Time (mean ± σ):      39.7 ms ±   2.9 ms    [User: 11.7 ms, System: 12.0 ms]
  Range (min … max):    33.1 ms …  45.4 ms    82 runs
```

A potential downside of this PR is that the commands specified in a hook **must not** affect the subsequent tmux commands. Since the two hooks subject to this limitation are rarely used, and few tmux commands have such an influence, it is acceptable to proceed.