### PR TITLE
fix: prefer printf to show variable values

### DIFF
--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env bash
 
+print() {
+	printf '%s' "$*"
+}
+
+println() {
+	printf '%s\n' "$*"
+}
+
 # Prints an error message and exits.
 die() {
-	echo "$*" >&2
+	println "$@" >&2
 	exit 1
 }
 
@@ -50,7 +58,7 @@ escape() {
 # Replace special chars with '_' in a session name.
 # See <https://github.com/tmux/tmux/blob/ef68debc8d9e0e5567d328766f705bb1f42b7c51/session.c#L242>
 escape_session_name() {
-	echo "${1//[.:]/_}"
+	print "${1//[.:]/_}"
 }
 
 # Parses tmux commands, assigning the tokens to an array named `cmds`.
@@ -62,7 +70,7 @@ parse_cmds() {
 		return 1
 	fi
 	# shellcheck disable=SC2034
-	IFS=$'\n' read -d '' -ra cmds < <(echo "$1" | xargs printf "%s\n") || true
+	IFS=$'\n' read -d '' -ra cmds < <(print "$1" | xargs printf "%s\n") || true
 }
 
 # Expands the provided tmux FORMAT string.
@@ -83,7 +91,7 @@ interpolate() {
 		result=${result//"{$key}"/$val}
 		shift
 	done
-	echo "$result"
+	print "$result"
 }
 
 #=== Test utils ===#
@@ -105,7 +113,7 @@ assert_eq() {
 begin_test() {
 	local source
 	source=$(basename "${BASH_SOURCE[1]}")
-	echo -e "[test] ${source%.*}::${1}"
+	echo "[test] ${source%.*}::${1}"
 }
 
 # Simulates the response of `batch_get_options`. It accepts arguments in the

--- a/src/helpers_tests.sh
+++ b/src/helpers_tests.sh
@@ -19,7 +19,7 @@ test_parse_commands() {
 	local i=0
 	while [[ $# -gt 0 ]]; do
 		if [[ $1 != "${cmds[$i]}" ]]; then
-			git diff <(echo "${cmds[i]}") <(echo "$1")
+			git diff <(print "${cmds[i]}") <(print "$1")
 			failf "unexpected token at $((i + 1))"
 		fi
 		shift

--- a/src/toggle_tests/open_nested_with_toggle_key.stdout
+++ b/src/toggle_tests/open_nested_with_toggle_key.stdout
@@ -36,6 +36,7 @@
 		working_pane_path
 		;
 		bind
+		-n
 		M-o
 		run
 		#{@popup-toggle} --name=p_nested_toggle_key_2 --toggle-key=-n\ M-o

--- a/src/toggle_tests/open_with_toggle_key.stdout
+++ b/src/toggle_tests/open_with_toggle_key.stdout
@@ -43,6 +43,7 @@
 		#{@popup-toggle} --name=p_toggle_key --toggle-key=-T\ root\ M-p --toggle-key=-n\ M-o
 		;
 		bind
+		-n
 		M-o
 		run
 		#{@popup-toggle} --name=p_toggle_key --toggle-key=-T\ root\ M-p --toggle-key=-n\ M-o
@@ -65,6 +66,7 @@
 	M-p
 	;
 	unbind
+	-n
 	M-o
 	;
 <<<TMUX:END[4]

--- a/src/toggle_tests/tmux
+++ b/src/toggle_tests/tmux
@@ -43,7 +43,7 @@ parse_output() {
 			# Fake a sh exec, redirecting output of nested tmux calls.
 			nested_call=1 sh -c "$1" 3>&1
 		else
-			echo "$1"
+			println "$1"
 		fi
 		shift
 	done


### PR DESCRIPTION
If a variable is `-n` or `-e`, it will be recognized as arguments for echo, which can lead to bugs that are extremely difficult to discover.