### PR TITLE
chore: release v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ although many are powered by some "dark" Bash magic =.=
 ### Changed
 
 - The `before-open` and `after-close` hooks are called in the same execution
-  that opens a popup window. This should rarely have side effects ([#46])
+  that opens the popup window. This should rarely have side effects ([#46])
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ follows <https://www.conventionalcommits.org/en/v1.0.0/> to track changes.
 
 ## [Unreleased]
 
+## [0.4.3] - {{DATE}}
+
+This release resolves a long-standing issue with `@popup-toggle` on macOS's
+ancient built-in Bash ([#44]). Thanks to [u/Beautiful_Baseball76] for the
+feedback , which also motivated me to add a number of integration tests,
+although many are powered by some "dark" Bash magic =.=
+
 ### Added
 
 - Distribute this plugin to nixpkgs ([#42], [NixOS/nixpkgs#428294], thanks
@@ -50,7 +57,7 @@ follows <https://www.conventionalcommits.org/en/v1.0.0/> to track changes.
 
 ### Fixed
 
-- Support OSX's ancient Bash ([#44])
+- Support macOS's ancient built-in Bash ([#44])
 - Forward all arguments when setting specified toggle keys ([#45])
 
 [#42]: https://github.com/loichyan/tmux-toggle-popup/pull/42
@@ -60,6 +67,7 @@ follows <https://www.conventionalcommits.org/en/v1.0.0/> to track changes.
 [#46]: https://github.com/loichyan/tmux-toggle-popup/pull/46
 [NixOS/nixpkgs#428294]: https://github.com/NixOS/nixpkgs/pull/428294
 [@szaffarano]: https://github.com/szaffarano
+[u/Beautiful_Baseball76]: https://www.reddit.com/user/Beautiful_Baseball76
 
 ## [0.4.2] - 2025-07-29
 
@@ -198,7 +206,8 @@ override popup global options on the fly using the newly added arguments of
 [README](https://github.com/loichyan/tmux-toggle-popup/blob/v0.1.0/README.md)
 for more details.
 
-[Unreleased]: https://github.com/loichyan/tmux-toggle-popup/compare/v0.4.2..HEAD
+[Unreleased]: https://github.com/loichyan/tmux-toggle-popup/compare/v0.4.3..HEAD
+[0.4.3]: https://github.com/loichyan/tmux-toggle-popup/compare/v0.4.2..v0.4.3
 [0.4.2]: https://github.com/loichyan/tmux-toggle-popup/compare/v0.4.1..v0.4.2
 [0.4.1]: https://github.com/loichyan/tmux-toggle-popup/compare/v0.4.0..v0.4.1
 [0.4.0]: https://github.com/loichyan/tmux-toggle-popup/compare/v0.3.0..v0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ follows <https://www.conventionalcommits.org/en/v1.0.0/> to track changes.
 
 ## [Unreleased]
 
-## [0.4.3] - {{DATE}}
+## [0.4.3] - 2025-08-14
 
 This release resolves a long-standing issue with `@popup-toggle` on macOS's
 ancient built-in Bash ([#44]). Thanks to [u/Beautiful_Baseball76] for the

--- a/toggle-popup.tmux
+++ b/toggle-popup.tmux
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Name:     tmux-toggle-popup
-# Version:  0.4.2
+# Version:  0.4.3
 # Authors:  Loi Chyan <loichyan@foxmail.com>
 # License:  MIT OR Apache-2.0
 


### PR DESCRIPTION
This release resolves a long-standing issue with `@popup-toggle` on macOS's ancient built-in Bash ([#44]). Thanks to [u/Beautiful_Baseball76] for the feedback , which also motivated me to add a number of integration tests, although many are powered by some "dark" Bash magic =.=

### Added

- Distribute this plugin to nixpkgs ([#42], [NixOS/nixpkgs#428294], thanks [@szaffarano])
- Support specifying the socket path for the popup server ([#43])

### Changed

- The `before-open` and `after-close` hooks are called in the same execution that opens the popup window. This should rarely have side effects ([#46])

### Fixed

- Support macOS's ancient built-in Bash ([#44])
- Forward all arguments when setting specified toggle keys ([#45])

[#42]: https://github.com/loichyan/tmux-toggle-popup/pull/42
[#43]: https://github.com/loichyan/tmux-toggle-popup/pull/43
[#44]: https://github.com/loichyan/tmux-toggle-popup/pull/44
[#45]: https://github.com/loichyan/tmux-toggle-popup/pull/45
[#46]: https://github.com/loichyan/tmux-toggle-popup/pull/46
[NixOS/nixpkgs#428294]: https://github.com/NixOS/nixpkgs/pull/428294
[@szaffarano]: https://github.com/szaffarano
[u/Beautiful_Baseball76]: https://www.reddit.com/user/Beautiful_Baseball76
