### PR TITLE
chore: release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ follows <https://www.conventionalcommits.org/en/v1.0.0/> to track changes.
 
 ## [Unreleased]
 
+## [0.5.1] - {{DATE}}
+
+This release improves the rules for argument expansion to resolve failures and
+potential issues on some systems.
+
 ### Changed
 
 - Only expand arguments that include format strings ([#65], [#66], thanks
@@ -278,4 +283,5 @@ for more details.
 [0.4.3]: https://github.com/loichyan/tmux-toggle-popup/compare/v0.4.2..v0.4.3
 [0.4.4]: https://github.com/loichyan/tmux-toggle-popup/compare/v0.4.3..v0.4.4
 [0.5.0]: https://github.com/loichyan/tmux-toggle-popup/compare/v0.4.4..v0.5.0
-[Unreleased]: https://github.com/loichyan/tmux-toggle-popup/compare/v0.5.0..HEAD
+[0.5.1]: https://github.com/loichyan/tmux-toggle-popup/compare/v0.5.0..v0.5.1
+[Unreleased]: https://github.com/loichyan/tmux-toggle-popup/compare/v0.5.1..HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ follows <https://www.conventionalcommits.org/en/v1.0.0/> to track changes.
 
 ## [Unreleased]
 
-## [0.5.1] - {{DATE}}
+## [0.5.1] - 2026-02-26
 
 This release improves the rules for argument expansion to resolve failures and
 potential issues on some systems.

--- a/USAGE.md
+++ b/USAGE.md
@@ -9,7 +9,7 @@ Some terms are emphasized in italics. Most of them are referred in the this sect
 Every popup is associated with a unique tmux session, namely the *popup
 session*, specified by an ID. When you open a popup through `@popup-toggle`:
 
-1. A *popup window* is created by `display-popup`,
+1. A *popup window* is created by `display-popup`.
 2. A tmux session specified by the given ID is created by `new-session` with the
    supplied program in the *popup server* if it does not already exist.
 3. Finally, the focus attaches to that session in the *popup window*.
@@ -18,7 +18,7 @@ The session from which you call `@popup-toggle` is the *working session*, or the
 *caller session*. Similarly, the pane where `@popup-toggle` runs is referred as
 the *caller pane*. In a *popup session*, you can invoke `@popup-toggle` again to
 close it and return to the *working session*. Closing a *popup session* does not
-exit it; instead, it keeps alive until the program running inside it exits.
+kill it; instead, it keeps alive until the program running inside it exits.
 
 In a *working session*, invoking `@popup-toggle` will always open a popup
 window. However, in a *popup session*, only if the specified ID matches the
@@ -68,7 +68,7 @@ both the working server and the *popup server*. `@popup-toggle` supports using
 `--toggle-key <key>` to achieve this, where `<key>` is passed to `bind-key` and
 can include any options supported by `bind-key`. For example, you can use
 `--toggle-key '-Troot M-t'` or `--toggle-key '-n M-t'` to bind `M-t` without the
-prefix key.
+prefix key. For more information about this option, please refer to [#9].
 
 If an argument passed to `@popup-toggle` contains format strings (i.e.,
 `#{...}`), it will be expanded using `tmux display-message` before being parsed.
@@ -80,6 +80,7 @@ use `run "#{@popup-toggle} -d'##{pane_current_path}'"` instead of
 `-d'#{pane_current_path}'`, and the same applies to other variables like
 `#{session_name}` and `#{session_path}`.
 
+[#9]: https://github.com/loichyan/tmux-toggle-popup/pull/9
 [#58]: https://github.com/loichyan/tmux-toggle-popup/pull/58
 
 ### `@popup-proxy`

--- a/toggle-popup.tmux
+++ b/toggle-popup.tmux
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Name:     tmux-toggle-popup
-# Version:  0.5.0
+# Version:  0.5.1
 # Authors:  Loi Chyan <loichyan@outlook.com>
 # License:  MIT OR Apache-2.0
 

--- a/toggle-popup.tmux
+++ b/toggle-popup.tmux
@@ -14,7 +14,7 @@ source "$CURRENT_DIR/src/helpers.sh"
 source "$CURRENT_DIR/src/variables.sh"
 
 main() {
-	# Set option defaults, and export public APIs.
+	# Set option defaults and export public commands.
 	tmux \
 		set-option -g @popup-toggle "$CURRENT_DIR/src/toggle.sh" \; \
 		set-option -g @popup-focus "$CURRENT_DIR/src/focus.sh" \; \


### PR DESCRIPTION
This release improves the rules for argument expansion to resolve failures and potential issues on some systems.

### Changed

- Only expand arguments that include format strings ([#65], [#66], thanks [@kwbr])

### Fixed

- Use strict matching for session names when switching popup sessions ([#67])

[#65]: https://github.com/loichyan/tmux-toggle-popup/pull/65
[#66]: https://github.com/loichyan/tmux-toggle-popup/pull/66
[#67]: https://github.com/loichyan/tmux-toggle-popup/pull/67
[@kwbr]: https://github.com/kwbr
